### PR TITLE
feat: AI enhancement, copilot, I2I & project management APIs (v1.1.0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -152,9 +152,35 @@ Thumbs.db
 *.png
 *.raw
 *.dng
+# RAW camera formats (sample/test photos must never be committed)
+*.arw
+*.ARW
+*.nef
+*.NEF
+*.cr2
+*.CR2
+*.cr3
+*.CR3
+*.raf
+*.RAF
+*.rw2
+*.RW2
+*.orf
+*.ORF
+*.pef
+*.PEF
+*.srw
+*.SRW
+# Apple HEIC/HEIF photos
+*.heic
+*.HEIC
+*.heif
+*.HEIF
 test_photos/
 examples/sample_photos/*.dng
 examples/edited
 output/
 downloads/
+# Eval / benchmark scratch workspace
+imagen-cli-workspace/
 CLAUDE.md

--- a/README.md
+++ b/README.md
@@ -140,6 +140,19 @@ async with ImagenClient("your_api_key") as client:
 - `download_files(download_links, output_dir="downloads", max_concurrent=5, progress_callback=None)` - Download files.
 - `get_profiles()` - List available editing profiles.
 
+#### **New in v1.1.0**
+- `list_projects(size=20, page=0, client_type=ClientType.API, is_archived=False, get_thumbnail=True)` - List projects (paginated).
+- `get_project(project_uuid, get_thumbnail=True)` / `get_project_uuid(project_name)` - Retrieve a project / resolve a name to UUID.
+- `get_sky_replacement_templates()` - List sky replacement templates (use a template's `id` for `EditOptions.sky_replacement_template_id`).
+- `get_export_upload_link(project_uuid, file_name)` / `get_export_download_link(project_uuid, file_name)` - Per-image export links.
+- `get_ai_tools(project_uuid)` - List AI enhancement tools for a project.
+- `enhance_image(project_uuid, filename, tool_id, parent_version_id=None)` - Apply an AI quick tool to an edited image.
+- `apply_copilot(project_uuid, filename, instruction, parent_version_id=None)` / `reset_copilot(project_uuid, filename)` - Natural-language editing via the AI copilot.
+- `finalize_project(project_uuid)` - Generate final download URLs, upscaling enhanced images.
+- I2I (image-to-image): `create_i2i_project`, `list_i2i_projects`, `validate_i2i_project_name`, `get_i2i_project`, `upload_i2i_images`, `upload_i2i_file_multipart`, `start_i2i_editing`, `get_i2i_download_links`, `get_i2i_download_link`.
+
+> **Base URL:** the SDK now targets production (`https://api.imagen-ai.com/v1`) by default. All existing methods are unchanged and fully backward compatible.
+
 ### **Popular functions**
 
 ```python
@@ -173,11 +186,115 @@ edit_options = EditOptions(
     hdr_merge=False
 )
 
-# Use photography types for optimization
+# Use photography types for optimization (now includes SCHOOL)
 photography_type = PhotographyType.WEDDING
 
 # Access crop ratios (if needed)
 ratio = CropAspectRatio.RATIO_2X3
+
+# New EditOptions fields (v1.1.0)
+from imagen_sdk import DNGCompression
+edit_options = EditOptions(
+    hdr_merge=True,
+    hdr_output_compression=DNGCompression.LOSSLESS,  # LOSSY (default) or LOSSLESS
+    callback_url="https://example.com/imagen-webhook",  # notified when editing completes
+)
+```
+
+---
+
+## 🤖 AI enhancement & copilot (v1.1.0)
+
+After a project has been edited, apply AI quick tools or natural-language instructions
+to individual images, then finalize to get upscaled deliverables.
+
+> **Prerequisites**
+> - **Export first.** The whole enhancement pipeline (`get_ai_tools`, `enhance_image`,
+>   `apply_copilot`, `finalize_project`) requires an **exported** project. Calling it on a
+>   project that hasn't finished exporting raises `ImagenError("API Error (400): Project
+>   has not been exported yet.")`. Run the standard edit → export flow first.
+> - **Realistic-only accounts.** Some accounts are restricted to "realistic" edits.
+>   Generative tools and copilot instructions classified as generative are rejected with
+>   `ImagenError("API Error (400): Only realistic editing requests are supported.")`.
+>   This is enforced by the editing service (not the SDK).
+
+```python
+from imagen_sdk import ImagenClient
+
+async with ImagenClient("your_api_key") as client:
+    # Discover available tools for the project
+    tools = await client.get_ai_tools(project_uuid)
+    for tool in tools.prompts:
+        print(tool.enhancement_type, "-", tool.label, "(batch:", tool.enabled_for_batch, ")")
+
+    # Apply a quick tool to one image (tool_id == a tool's enhancement_type)
+    result = await client.enhance_image(project_uuid, "IMG_0001.jpg", tool_id="remove_cameraman")
+    print(result.status, result.version_id, result.enhanced_image_url)
+
+    # Or instruct the AI copilot in natural language (returns the same EnhanceResult shape)
+    await client.apply_copilot(project_uuid, "IMG_0001.jpg", "add warm twilight lighting")
+    # Reset the copilot conversation for an image if needed
+    await client.reset_copilot(project_uuid, "IMG_0001.jpg")
+
+    # Generate final download URLs (upscales enhanced images)
+    final = await client.finalize_project(project_uuid)
+    for f in final.files_list:
+        print(f.file_name, f.download_link)
+```
+
+### Sky replacement templates
+
+```python
+templates = await client.get_sky_replacement_templates()
+default = next((t for t in templates if t.is_default), templates[0])
+
+edit_options = EditOptions(sky_replacement=True, sky_replacement_template_id=default.id)
+```
+
+## 🖼️ Image-to-image (I2I)
+
+The I2I workflow has its own project namespace and supports multipart uploads for large
+files. Note there is no I2I status endpoint — completion is signalled via `callback_url`
+or by polling `get_i2i_download_links` until links appear.
+
+```python
+from imagen_sdk import ImagenClient, I2IEditOptions
+
+async with ImagenClient("your_api_key") as client:
+    project_uuid = await client.create_i2i_project("My I2I Project")
+
+    # Small files: standard concurrent upload
+    await client.upload_i2i_images(project_uuid, ["image1.jpg", "image2.jpg"])
+
+    # Large files: chunked multipart upload (auto split / complete, aborts on failure)
+    await client.upload_i2i_file_multipart(project_uuid, "huge_scan.tif")
+
+    edit = await client.start_i2i_editing(
+        project_uuid,
+        I2IEditOptions(perspective_correction=True, callback_url="https://example.com/hook"),
+    )
+    print(edit.message)
+
+    # All files at once...
+    links = await client.get_i2i_download_links(project_uuid)
+    await client.download_files(links, "i2i_output")
+
+    # ...or a single file's link
+    single = await client.get_i2i_download_link(project_uuid, "image1.jpg")
+    print(single.download_link)
+```
+
+## 📂 Project management (v1.1.0)
+
+```python
+async with ImagenClient("your_api_key") as client:
+    listing = await client.list_projects(size=20, page=0)
+    print(f"{listing.pagination.total} projects total")
+    for project in listing.projects:
+        print(project.project_uuid, project.name, project.status)
+
+    one = await client.get_project(listing.projects[0].project_uuid)
+    uuid = await client.get_project_uuid("My Project Name")
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -253,9 +253,14 @@ edit_options = EditOptions(sky_replacement=True, sky_replacement_template_id=def
 
 ## 🖼️ Image-to-image (I2I)
 
-The I2I workflow has its own project namespace and supports multipart uploads for large
-files. Note there is no I2I status endpoint — completion is signalled via `callback_url`
-or by polling `get_i2i_download_links` until links appear.
+The I2I workflow has its own project namespace. Note there is no I2I status endpoint —
+completion is signalled via `callback_url` or by polling `get_i2i_download_links` until
+links appear.
+
+`upload_i2i_images` is the recommended entry point: it routes each file automatically by
+size — small files use a batched single PUT, files above `multipart_threshold` (default
+64 MB) use chunked multipart upload. You don't pick the method. (Multipart is I2I-only;
+the standard `upload_images` flow has no multipart path.)
 
 ```python
 from imagen_sdk import ImagenClient, I2IEditOptions
@@ -263,11 +268,11 @@ from imagen_sdk import ImagenClient, I2IEditOptions
 async with ImagenClient("your_api_key") as client:
     project_uuid = await client.create_i2i_project("My I2I Project")
 
-    # Small files: standard concurrent upload
-    await client.upload_i2i_images(project_uuid, ["image1.jpg", "image2.jpg"])
+    # Auto-routed: small files -> single PUT, large files -> multipart, transparently
+    await client.upload_i2i_images(project_uuid, ["image1.jpg", "huge_scan.tif"])
 
-    # Large files: chunked multipart upload (auto split / complete, aborts on failure)
-    await client.upload_i2i_file_multipart(project_uuid, "huge_scan.tif")
+    # (Advanced escape hatch — force multipart for one file)
+    # await client.upload_i2i_file_multipart(project_uuid, "huge_scan.tif")
 
     edit = await client.start_i2i_editing(
         project_uuid,

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -1,0 +1,589 @@
+# Imagen AI SDK — Workflows
+
+> **Purpose of this document.** This is a language-neutral description of every
+> workflow the SDK orchestrates, written so it can serve as the *behavioral
+> contract* for any SDK implementation (Python today; Node/Go/C#/etc. later).
+> It captures not just *which* endpoints exist, but *how they are sequenced*,
+> *how completion is detected*, *what concurrency and retry behavior is
+> expected*, and *which rules every implementation must honor*. Reproduce this
+> behavior and an SDK in any language will behave identically.
+>
+> Where this document and the code disagree, the code is the current truth and
+> this document should be corrected.
+
+---
+
+## Table of contents
+
+1. [Concepts and terminology](#1-concepts-and-terminology)
+2. [Shared foundations (used by every workflow)](#2-shared-foundations-used-by-every-workflow)
+3. [Project families ("project types")](#3-project-families-project-types)
+4. [Workflow A — Standard editing (Regular projects)](#4-workflow-a--standard-editing-regular-projects)
+5. [Workflow B — Export to JPEG (Regular projects)](#5-workflow-b--export-to-jpeg-regular-projects)
+6. [Workflow C — AI Enhancement / Copilot / Finalize](#6-workflow-c--ai-enhancement--copilot--finalize)
+7. [Workflow D — Image-to-Image (I2I) projects](#7-workflow-d--image-to-image-i2i-projects)
+8. [Workflow E — Project management & discovery](#8-workflow-e--project-management--discovery)
+9. [Photography types and recommended edit options](#9-photography-types-and-recommended-edit-options)
+10. [Endpoint reference](#10-endpoint-reference)
+11. [Cross-language portability checklist](#11-cross-language-portability-checklist)
+
+---
+
+## 1. Concepts and terminology
+
+| Term | Meaning |
+|------|---------|
+| **Project** | Server-side container for a batch of images and their edits, addressed by a `project_uuid`. |
+| **Project family** | The endpoint namespace a project lives under. Two exist: **Regular** (`/projects/...`) and **Image-to-Image / I2I** (`/i2i/projects/...`). This is the true "project type" split — they have different endpoints and different completion semantics. |
+| **Profile** | A trained AI editing style, identified by an integer `profile_key`. Each profile is bound to one **image type** (`RAW` or `JPG`). |
+| **Photography type** | An optional hint passed to editing (`WEDDING`, `REAL_ESTATE`, …). It does **not** change the workflow — only which edit options make sense. |
+| **Edit** | AI editing pass that produces **XMP** sidecar files (Lightroom-compatible edit instructions). The original images are never modified. |
+| **Export** | Optional pass that renders the edited images to final **JPEG** files for delivery. |
+| **Enhancement / Copilot** | Per-image, post-edit AI operations (quick tools and natural-language instructions), versioned per image. |
+| **Finalize** | Generates final download URLs for a project, upscaling any enhanced images. |
+| **Presigned URL** | A temporary, direct-to-storage (S3) URL. Uploads `PUT` to it; downloads `GET` from it. The Imagen API itself never proxies file bytes. |
+
+A key architectural fact reflected throughout: **the Imagen API only ever hands
+out presigned URLs and project state. All file bytes move directly between the
+client and object storage.** Every upload and download workflow is therefore a
+two-phase pattern: (1) ask the API for links, (2) transfer bytes to/from storage.
+
+---
+
+## 2. Shared foundations (used by every workflow)
+
+These behaviors are identical across all workflows and should be implemented
+once per language, then reused.
+
+### 2.1 Client, session, authentication
+
+- **Base URL (production):** `https://api.imagen-ai.com/v1`
+- **Auth header:** `x-api-key: <API_KEY>` on every API request.
+- **User-Agent:** `Imagen-Python-SDK/<version>` (adjust per language, e.g. `Imagen-Go-SDK/...`).
+- **HTTP timeout:** `300s` for API and storage transfers.
+- A single reusable HTTP session/connection pool is created lazily and closed
+  explicitly (the Python SDK uses an async context manager; other languages
+  should provide the idiomatic equivalent — `defer client.Close()`, `using`, etc.).
+- The API key must be validated as non-empty at construction time.
+
+### 2.2 Request/response envelope handling
+
+Responses come in **two shapes** and implementations must tolerate both:
+
+- **Production:** payload at the root, e.g. `{"project_uuid": "..."}`.
+- **Legacy/beta:** the same payload wrapped in a sole `data` key, e.g. `{"data": {"project_uuid": "..."}}`.
+
+**Unwrap rule:** if the response is an object whose *only* key is `data`, use
+`response["data"]`; otherwise use the response as-is. Apply this unwrap before
+validating any response model.
+
+### 2.3 HTTP error mapping
+
+| Condition | Behavior |
+|-----------|----------|
+| `401` | Raise **AuthenticationError** ("Invalid API key or unauthorized"). |
+| `>= 400` (other) | Extract the message from the JSON body, preferring `error.message` (the production shape `{"error": {"message": ...}}`), falling back to `detail`, then to raw text; raise **ImagenError** as `API Error (<status>): <message>`. |
+| `204 No Content` | Treat as success with an empty body. |
+| Network/transport failure | Raise **ImagenError** ("Request failed: …"). |
+
+### 2.4 Error hierarchy
+
+```
+ImagenError (base)
+├── AuthenticationError   — 401 / bad key
+├── ProjectError          — project create / edit / export / status / parse failures
+├── UploadError           — no valid files, missing link, storage PUT failure
+└── DownloadError         — no links provided, all downloads failed
+```
+
+Validation failures when parsing a response into a model are raised as the
+context-appropriate type (e.g. parsing the create-project response failure →
+`ProjectError`).
+
+### 2.5 Concurrent upload (shared by Regular and I2I standard uploads)
+
+Inputs: a list of local paths, a `max_concurrent` limit (default **5**, must be
+≥ 1), an optional `calculate_md5` flag, and an optional progress callback.
+
+Algorithm:
+
+1. **Validate paths.** Keep files that exist and are regular files; **skip**
+   (with a warning) anything else. If *nothing* valid remains, raise `UploadError`.
+2. **Build upload-info list.** For each valid file: `{ file_name, md5? }`.
+   Compute MD5 (base64-encoded) only when `calculate_md5` is true.
+3. **Request presigned upload links** from the family's upload-links endpoint.
+   Build a `file_name → upload_link` map from the response.
+4. **Upload concurrently** under a semaphore of size `max_concurrent`:
+   - Look up the file's upload link (missing link → that file fails).
+   - `PUT` the file bytes to the presigned URL; `raise_for_status()`.
+   - Per-file failures are **captured, not fatal** — record `{file, success, error}`.
+   - Fire the progress callback before and after each file.
+5. **Return an `UploadSummary`**: `{ total, successful, failed, results[] }`.
+
+> Partial success is by design: some files can fail while others succeed. Callers
+> decide what to do based on `successful`/`failed`.
+
+### 2.6 Concurrent download (shared by all workflows)
+
+Inputs: a list of download URLs, an output directory, `max_concurrent` (default
+**5**, ≥ 1), optional progress callback.
+
+Algorithm:
+
+1. Create the output directory (recursively) if missing.
+2. If the link list is empty, raise `DownloadError`.
+3. Download concurrently under a semaphore:
+   - Derive the filename from the URL path (URL-decoded). If it has no usable
+     name+extension, fall back to `imagen_edited_{index:05d}.jpg`.
+   - `GET` the URL, `raise_for_status()`, stream/write bytes to disk.
+   - Per-file failures are captured, not fatal.
+4. If **every** download failed, raise `DownloadError`; otherwise return the list
+   of successfully written local paths.
+
+### 2.7 Status polling (Regular edit & export only)
+
+Used by `start_editing` and `export_project`. **I2I has no status endpoint** (see
+Workflow D).
+
+- **Endpoint:** `GET /projects/{uuid}/{operation}/status` where `operation ∈ {edit, export}`.
+- **Initial interval:** `10s`.
+- **Backoff:** multiply interval by `1.2` after each poll, **capped at 60s**.
+- **Max wait:** `72000s` (20 hours); exceeding it raises `ProjectError` (timeout).
+- **Terminal states:**
+  - `"Completed"` → return the final `StatusDetails`.
+  - `"Failed"` → raise `ProjectError`, appending `details` if present.
+  - any other status → keep polling.
+- `StatusDetails` shape: `{ status: str, progress?: float, details?: str }`.
+
+```mermaid
+flowchart TD
+    A[Trigger operation] --> B[Wait check_interval]
+    B --> C[GET /.../status]
+    C --> D{status?}
+    D -->|Completed| E[Return StatusDetails]
+    D -->|Failed| F[Raise ProjectError]
+    D -->|other| G{elapsed > 20h?}
+    G -->|yes| H[Raise ProjectError timeout]
+    G -->|no| I[interval = min interval*1.2, 60s]
+    I --> B
+```
+
+### 2.8 File type rules
+
+- A project is **homogeneous**: all files in one project must be the same type —
+  **all RAW** or **all JPEG**. They must also match the chosen profile's `image_type`.
+- **RAW extensions:** `.dng .nef .cr2 .arw .nrw .crw .srf .sr2 .orf .raw .rw2 .raf .ptx .pef .rwl .srw .cr3 .3fr .fff`
+- **JPEG extensions:** `.jpg .jpeg`
+- A pre-upload validation helper (`check_files_match_profile_type`) compares the
+  file set against the profile's type and raises `UploadError` on any mismatch,
+  mixed types, or unsupported extension. Implementations should provide an
+  equivalent guard.
+
+---
+
+## 3. Project families ("project types")
+
+Two project families exist. Everything else (photography type, edit options,
+enhancement) is a *parameter* or *sub-operation* within a family.
+
+| Aspect | **Regular** (`/projects`) | **Image-to-Image / I2I** (`/i2i/projects`) |
+|--------|---------------------------|--------------------------------------------|
+| Primary output | XMP edits (+ optional JPEG export) | Edited images downloaded directly |
+| Profile required | **Yes** (`profile_key`) | **No** |
+| Status endpoint | **Yes** (`/edit/status`, `/export/status`) | **No** — completion via callback or download-link polling |
+| Large-file upload | Standard concurrent PUT | Standard **or** S3 **multipart** upload |
+| Edit options model | `EditOptions` (rich) | `I2IEditOptions` (subset) |
+| Export step | Yes (`/export`) | No (no separate export pass) |
+| Enhancement/Copilot/Finalize | Yes (`project_source=REGULAR`) | Yes (`project_source=I2I`) |
+
+The shared foundations in §2 apply to both families. The sections below describe
+each family's end-to-end flow.
+
+---
+
+## 4. Workflow A — Standard editing (Regular projects)
+
+The core flow and the one most users run. Produces XMP edit files.
+
+```mermaid
+sequenceDiagram
+    participant U as Caller
+    participant API as Imagen API
+    participant S3 as Object storage
+    U->>API: 1. POST /projects/ (name?)
+    API-->>U: project_uuid
+    U->>API: 2. POST /projects/{uuid}/get_temporary_upload_links (files_list)
+    API-->>U: presigned upload links
+    U->>S3: 2b. PUT each file (concurrent)
+    U->>API: 3. POST /projects/{uuid}/edit (profile_key, options) [Content-Type: ""]
+    loop poll until terminal (§2.7)
+        U->>API: 4. GET /projects/{uuid}/edit/status
+        API-->>U: status (In Progress / Completed / Failed)
+    end
+    U->>API: 5. GET /projects/{uuid}/edit/get_temporary_download_links
+    API-->>U: XMP download links
+    U->>S3: 6. GET each link (concurrent) -> local files
+```
+
+### Steps
+
+| # | Operation | Endpoint | Notes |
+|---|-----------|----------|-------|
+| 1 | **Create project** | `POST /projects/` | Body `{name?}`. Name must be unique per account; omit to get a server-generated UUID. Returns `project_uuid`. |
+| 2 | **Upload images** | `POST /projects/{uuid}/get_temporary_upload_links` then PUT to storage | Uses the shared concurrent upload (§2.5). Body `{ files_list: [{file_name, md5?}] }`. |
+| 3 | **Start editing** | `POST /projects/{uuid}/edit` | Body `{ profile_key, photography_type?, ...edit_options }`. **Quirk:** send an explicitly empty `Content-Type: ""` header (the API rejects the default JSON content type here). |
+| 4 | **Poll status** | `GET /projects/{uuid}/edit/status` | Shared polling (§2.7). Blocks until `Completed`/`Failed`. |
+| 5 | **Get download links** | `GET /projects/{uuid}/edit/get_temporary_download_links` | Returns list of XMP download URLs. |
+| 6 | **Download files** | (storage GET) | Shared concurrent download (§2.6). |
+
+### Notes & invariants
+
+- `start_editing` **blocks** (it includes step 4's polling). A non-blocking
+  variant can be offered, but the default contract is "returns when editing is done."
+- `profile_key` is required and must match the file type (validate with §2.8).
+- Editing produces XMP only; the originals are untouched.
+
+### One-call convenience: `quick_edit`
+
+A high-level wrapper that runs the whole flow. Order of operations:
+
+1. Fetch the profile by key and validate file types against it (§2.8).
+2. Create project → upload images.
+3. **Abort if `upload_summary.successful == 0`** (raise `UploadError`).
+4. `start_editing` (with optional `photography_type` + `edit_options`).
+5. Get XMP download links.
+6. If `export=True`: run Workflow B, capturing export links (re-raise on failure).
+7. If `download=True`: download XMP files; if export links exist, download those
+   too (default export subdir is `<download_dir>/exported`).
+8. Return `QuickEditResult { project_uuid, upload_summary, download_links,
+   export_links?, downloaded_files?, exported_files? }`.
+
+---
+
+## 5. Workflow B — Export to JPEG (Regular projects)
+
+Optional pass after editing completes. Renders final client-ready JPEGs.
+
+```mermaid
+sequenceDiagram
+    participant U as Caller
+    participant API as Imagen API
+    participant S3 as Object storage
+    U->>API: 1. POST /projects/{uuid}/export
+    loop poll until terminal (§2.7)
+        U->>API: 2. GET /projects/{uuid}/export/status
+        API-->>U: status
+    end
+    U->>API: 3. GET /projects/{uuid}/export/get_temporary_download_links
+    API-->>U: JPEG download links
+    U->>S3: 4. GET each link (concurrent) -> local files
+```
+
+| # | Operation | Endpoint | Notes |
+|---|-----------|----------|-------|
+| 1 | **Start export** | `POST /projects/{uuid}/export` | No body required. |
+| 2 | **Poll status** | `GET /projects/{uuid}/export/status` | Shared polling (§2.7), `operation = export`. |
+| 3 | **Get export links** | `GET /projects/{uuid}/export/get_temporary_download_links` | Returns final JPEG download URLs. |
+| 4 | **Download** | (storage GET) | Shared concurrent download (§2.6). |
+
+**Per-image export links** are also available (used for advanced flows):
+- `GET /projects/{uuid}/export/get_upload_link?file_name=` → presigned upload link for a single exported image.
+- `GET /projects/{uuid}/export/get_download_link?file_name=` → download link for a single exported image.
+
+**Precondition:** editing (Workflow A) must have completed for the project.
+
+---
+
+## 6. Workflow C — AI Enhancement / Copilot / Finalize
+
+Per-image, post-edit AI operations. Works on **already-edited** images in either
+project family (pass `project_source = REGULAR | I2I`). Endpoints live under the
+`/projects/...` namespace regardless of family; the family is selected via the
+`project_source` parameter/body field.
+
+> **Preconditions (verified against the API gateway):**
+> - **Export first.** For Regular projects every operation in this workflow
+>   (`get_ai_tools`, `enhance_image`, `apply_copilot`, `finalize_project`) requires the
+>   project's export to have completed; otherwise the gateway returns
+>   `400 "Project has not been exported yet."` (I2I projects gate on the project being
+>   `Completed` instead.)
+> - **Realistic-only gating.** Whether a given tool/instruction is permitted is decided
+>   by the downstream editing service, **not** the gateway. Restricted accounts reject
+>   generative requests (and copilot instructions classified as generative) with
+>   `400 "Only realistic editing requests are supported."` A reimplementation cannot
+>   predict this locally; surface the API error. The `enabled_for_batch` flag on each
+>   tool is passed through opaquely and does not, by itself, gate realistic vs. generative.
+
+```mermaid
+flowchart LR
+    A[get_ai_tools] --> B[enhance_image / apply_copilot]
+    B --> C{more edits?}
+    C -->|yes, build on parent_version_id| B
+    C -->|start over| D[reset_copilot]
+    D --> B
+    C -->|done| E[finalize_project]
+    E --> F[download final URLs]
+```
+
+| Operation | Endpoint | Notes |
+|-----------|----------|-------|
+| **List AI tools** | `GET /projects/{uuid}/ai-tools?project_source=` | Returns `{ prompts: [{ enhancement_type, label?, enabled_for_batch? }] }`. Use a tool's `enhancement_type` as the `tool_id` below. Extra fields are preserved. |
+| **Enhance image** | `POST /projects/{uuid}/images/{filename}/enhance` | Body `{ tool_id, parent_version_id?, project_source }`. Applies a quick tool to one image. |
+| **Apply copilot** | `POST /projects/{uuid}/images/{filename}/copilot` | Body `{ instruction (1–255 chars), parent_version_id?, project_source }`. Natural-language edit. |
+| **Reset copilot** | `DELETE /projects/{uuid}/images/{filename}/copilot` | Body `{ project_source }`. Clears the image's copilot conversation history. |
+| **Finalize project** | `POST /projects/{uuid}/finalize` | Body `{ project_source }`. Generates final download URLs, upscaling enhanced images. |
+
+### Versioning model
+
+Enhancements and copilot instructions are **versioned per image**. Passing
+`parent_version_id` builds a new version *on top of* a prior one, enabling an
+iterative chain. Omitting it starts from the base edited image. `reset_copilot`
+discards the conversation history so the next instruction starts fresh.
+
+> **Response shapes (verified against the API gateway source, v1.1.0):**
+> - `enhance_image` and `apply_copilot` both return the server's `AIEnhancementResponse`
+>   → modeled as **`EnhanceResult`** `{ status: str, version_id: any (nullable),
+>   enhanced_image_url: str }`.
+> - `finalize_project` returns the same shape as the download-links endpoints →
+>   **`DownloadLinksList`** `{ files_list: [{ file_name, download_link }] }`.
+> - `start_i2i_editing` returns **`MessageResponse`** `{ message: str }`.
+> - `get_i2i_download_link` (single image) returns **`SingleDownloadLink`**
+>   `{ download_link: str }`.
+>
+> All models allow unknown extra fields for forward compatibility. `version_id` is
+> intentionally untyped because the server declares it as an open, optional field.
+
+---
+
+## 7. Workflow D — Image-to-Image (I2I) projects
+
+A separate project family with its own endpoints. The defining differences:
+**no profile**, **no status endpoint**, and support for **S3 multipart upload**
+of very large files.
+
+```mermaid
+sequenceDiagram
+    participant U as Caller
+    participant API as Imagen API
+    participant S3 as Object storage
+    U->>API: 1. POST /i2i/projects/ (name?)
+    API-->>U: project_uuid
+    alt small files
+        U->>API: 2a. POST /i2i/projects/{uuid}/get_temporary_upload_links
+        API-->>U: presigned links
+        U->>S3: PUT each file (concurrent)
+    else large file
+        U->>API: 2b. POST /i2i/projects/{uuid}/multipart_uploads (file_name, part_count)
+        API-->>U: upload_id, key, part URLs
+        U->>S3: PUT each part (concurrent)
+        U->>API: POST /i2i/projects/{uuid}/multipart_uploads/{upload_id}/complete
+    end
+    U->>API: 3. POST /i2i/projects/{uuid}/edit (i2i options)
+    Note over U,API: No status endpoint. Wait for callback_url<br/>OR poll download links until non-empty.
+    U->>API: 4. GET /i2i/projects/{uuid}/get_temporary_download_links
+    API-->>U: download links (once ready)
+    U->>S3: 5. GET each link (concurrent) -> local files
+```
+
+### Project lifecycle
+
+| Operation | Endpoint | Notes |
+|-----------|----------|-------|
+| Create | `POST /i2i/projects/` | Body `{name?}` → `project_uuid`. |
+| List | `GET /i2i/projects` | Params `{size, page, is_archived?}`. |
+| Validate name | `GET /i2i/projects/is_valid_name?name=` | Returns bool; a 2xx with no explicit flag is treated as valid. |
+| Get one | `GET /i2i/projects/{uuid}?get_thumbnail=` | Returns a `ProjectListItem`. |
+
+### Upload — standard
+
+`POST /i2i/projects/{uuid}/get_temporary_upload_links` then concurrent PUT
+(§2.5). Body uses `{ files_list, client_type }` (defaults `client_type = API`).
+
+Single-file link: `GET /i2i/projects/{uuid}/get_upload_link?file_name=`.
+
+### Upload — multipart (large files)
+
+For one large file, split into parts and upload each to its own presigned URL.
+
+- **Part size:** default **64 MB** (S3 requires ≥ 5 MB per part except the last).
+- **Part count:** `ceil(file_size / part_size)`, minimum 1, range 1–10000.
+- **Concurrency:** default **4** concurrent parts.
+- **Memory bound:** read each chunk *inside* the semaphore so peak memory is
+  bounded to `max_concurrent × part_size`.
+- **Steps:**
+  1. `POST /i2i/projects/{uuid}/multipart_uploads` with `{ file_name, part_count }`
+     → `{ upload_id, key, parts: [{ part_number, upload_url }] }`.
+  2. For each part: seek to `(part_number - 1) * part_size`, read `part_size`
+     bytes, `PUT` to `upload_url`.
+  3. `POST /i2i/projects/{uuid}/multipart_uploads/{upload_id}/complete` with `{ file_name }`.
+- **Failure handling (mandatory):** on *any* part/complete failure, call
+  `DELETE /i2i/projects/{uuid}/multipart_uploads/{upload_id}` with `{ key }` to
+  abort the upload, then raise `UploadError`. Abort failures are logged but the
+  original error is what propagates.
+
+### Editing & completion
+
+- **Trigger:** `POST /i2i/projects/{uuid}/edit` with optional `I2IEditOptions`
+  (`hdr_merge`, `sky_replacement`, `sky_replacement_template_id`,
+  `perspective_correction`, `callback_url`). Returns immediately with a
+  `MessageResponse` `{ message }`.
+- **Completion detection (critical difference):** there is **no status
+  endpoint**. Two supported strategies:
+  1. **Webhook:** provide `callback_url` in the edit options; the server calls it on completion.
+  2. **Poll downloads:** call `get_i2i_download_links` periodically until it
+     returns a non-empty list. (Polling cadence is the caller's choice; reuse the
+     §2.7 backoff shape for consistency.)
+
+### Download
+
+- All images: `GET /i2i/projects/{uuid}/get_temporary_download_links` → URLs,
+  then shared concurrent download (§2.6).
+- Single image: `GET /i2i/projects/{uuid}/get_download_link?file_name=` →
+  `SingleDownloadLink` `{ download_link }`.
+
+---
+
+## 8. Workflow E — Project management & discovery
+
+Supporting read/discovery operations used across the other workflows. None of
+these mutate edits; they exist to find IDs, profiles, and templates.
+
+| Operation | Endpoint | Returns |
+|-----------|----------|---------|
+| **List profiles** | `GET /profiles` | `Profile[]` — `{ image_type, profile_key, profile_name, profile_type }`. Accepts a bare list (prod) or `{data:{profiles:[…]}}` (legacy). |
+| **Get one profile** | (client-side filter of `GET /profiles`) | Single `Profile` by key; raises `UploadError` if not found. |
+| **List projects** | `GET /projects` | `{ projects: ProjectListItem[], pagination: {total,size,page} }`. Params `{size,page,client_type,is_archived?,get_thumbnail}`. |
+| **Get project** | `GET /projects/{uuid}?get_thumbnail=` | `ProjectListItem`. |
+| **Resolve name → UUID** | `GET /projects/{name}/uuid` | UUID string (tolerates `str`, `{project_uuid}`, or `{uuid}` shapes). |
+| **List sky templates** | `GET /projects/sky_replacement/templates` | `SkyTemplate[]` — `{ id, is_default }`; use `id` for `EditOptions.sky_replacement_template_id`. |
+
+**Standalone convenience functions** mirror these for one-shot use without
+managing a client instance: `get_profiles`, `get_profile`,
+`get_sky_replacement_templates`, `list_projects`, `get_ai_tools`. Each spins up a
+temporary client, runs the call, and tears it down.
+
+### Pagination
+
+List endpoints are zero-based: `page` starts at `0`, `size` is 1–100 (default
+20). `pagination.total` is the full count; iterate pages until
+`page * size >= total`.
+
+---
+
+## 9. Photography types and recommended edit options
+
+Photography type is a single optional argument to `start_editing`
+(`photography_type`); it does **not** branch the workflow. What changes per type
+is which `EditOptions` are meaningful. The table below is the practical mapping
+(derived from the SDK examples) — implementations don't enforce it, but SDK docs
+and helpers should steer users toward it.
+
+| Photography type | Typical edit options |
+|------------------|----------------------|
+| `PORTRAITS` | `portrait_crop`, `smooth_skin`, `subject_mask`, `straighten` |
+| `WEDDING` | `portrait_crop`, `smooth_skin`, `subject_mask`, `straighten` |
+| `FAMILY_NEWBORN` / `BOUDOIR` | `portrait_crop` or `headshot_crop`, `smooth_skin`, `subject_mask` |
+| `SCHOOL` / headshots | `headshot_crop`, `smooth_skin`, `perspective_correction`, `subject_mask` |
+| `REAL_ESTATE` | `crop`, `perspective_correction`, `window_pull`, `hdr_merge`, `crop_aspect_ratio`, optional `sky_replacement` (+ template id) |
+| `LANDSCAPE_NATURE` | `crop`, `straighten`, `sky_replacement` (+ template id), `hdr_merge` |
+| `EVENTS` / `SPORTS` | `crop`, `straighten`, `subject_mask` |
+| `OTHER` / `NO_TYPE` | `crop`, `straighten` (general defaults) |
+
+### `EditOptions` reference and rules
+
+Full option set: `crop`, `straighten`, `hdr_merge`, `portrait_crop`,
+`smooth_skin`, `subject_mask`, `headshot_crop`, `perspective_correction`,
+`sky_replacement`, `sky_replacement_template_id`, `window_pull`,
+`crop_aspect_ratio`, `callback_url`, `hdr_output_compression` (`LOSSY|LOSSLESS`).
+
+**Mutual-exclusivity rules (must be enforced client-side, fail fast):**
+
+- At most **one crop mode**: `crop`, `headshot_crop`, `portrait_crop`.
+- At most **one straightening mode**: `straighten`, `perspective_correction`.
+
+Violations raise a validation error before any request is sent. The payload is
+serialized with null fields omitted (`exclude_none`), so only explicitly-set
+options are transmitted.
+
+`I2IEditOptions` is the I2I subset: `hdr_merge`, `sky_replacement`,
+`sky_replacement_template_id`, `perspective_correction`, `callback_url`.
+
+---
+
+## 10. Endpoint reference
+
+All paths are relative to `https://api.imagen-ai.com/v1`. Auth header
+`x-api-key` on every call.
+
+### Regular projects
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| POST | `/projects/` | Create project |
+| GET | `/projects` | List projects (paginated) |
+| GET | `/projects/{uuid}` | Get one project |
+| GET | `/projects/{name}/uuid` | Resolve name → UUID |
+| POST | `/projects/{uuid}/get_temporary_upload_links` | Get upload links |
+| POST | `/projects/{uuid}/edit` | Start editing (`Content-Type: ""`) |
+| GET | `/projects/{uuid}/edit/status` | Edit status (poll) |
+| GET | `/projects/{uuid}/edit/get_temporary_download_links` | XMP download links |
+| POST | `/projects/{uuid}/export` | Start export |
+| GET | `/projects/{uuid}/export/status` | Export status (poll) |
+| GET | `/projects/{uuid}/export/get_temporary_download_links` | JPEG export links |
+| GET | `/projects/{uuid}/export/get_upload_link?file_name=` | Per-image export upload link |
+| GET | `/projects/{uuid}/export/get_download_link?file_name=` | Per-image export download link |
+| GET | `/projects/sky_replacement/templates` | Sky templates |
+| GET | `/profiles` | List profiles |
+
+### Enhancement / Copilot / Finalize (family via `project_source`)
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| GET | `/projects/{uuid}/ai-tools?project_source=` | List AI tools |
+| POST | `/projects/{uuid}/images/{filename}/enhance` | Apply quick tool |
+| POST | `/projects/{uuid}/images/{filename}/copilot` | Apply NL instruction |
+| DELETE | `/projects/{uuid}/images/{filename}/copilot` | Reset copilot history |
+| POST | `/projects/{uuid}/finalize` | Finalize (generate final URLs) |
+
+### I2I projects
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| POST | `/i2i/projects/` | Create I2I project |
+| GET | `/i2i/projects` | List I2I projects |
+| GET | `/i2i/projects/is_valid_name?name=` | Validate name |
+| GET | `/i2i/projects/{uuid}` | Get one I2I project |
+| POST | `/i2i/projects/{uuid}/get_temporary_upload_links` | Get upload links |
+| GET | `/i2i/projects/{uuid}/get_upload_link?file_name=` | Single upload link |
+| POST | `/i2i/projects/{uuid}/multipart_uploads` | Create multipart upload |
+| POST | `/i2i/projects/{uuid}/multipart_uploads/{upload_id}/complete` | Complete multipart |
+| DELETE | `/i2i/projects/{uuid}/multipart_uploads/{upload_id}` | Abort multipart (body `{key}`) |
+| POST | `/i2i/projects/{uuid}/edit` | Trigger I2I edit (no status) |
+| GET | `/i2i/projects/{uuid}/get_temporary_download_links` | All download links |
+| GET | `/i2i/projects/{uuid}/get_download_link?file_name=` | Single download link |
+
+---
+
+## 11. Cross-language portability checklist
+
+When porting these workflows to another language, an implementation is
+"correct" when it reproduces all of the following behaviors:
+
+- [ ] `x-api-key` auth, 300s timeouts, reusable session, language-appropriate `User-Agent`.
+- [ ] Envelope unwrap rule (sole `data` key) applied before every model parse (§2.2).
+- [ ] HTTP error mapping incl. 401 → AuthenticationError and message extraction (`error.message` → `detail` → raw text) (§2.3).
+- [ ] The four-type error hierarchy (§2.4).
+- [ ] Concurrent upload with default concurrency 5, path validation/skip, partial-success summary (§2.5).
+- [ ] Concurrent download with filename derivation + fallback, partial success, all-fail → error (§2.6).
+- [ ] Polling: start 10s, ×1.2 backoff capped at 60s, 20h max, terminal `Completed`/`Failed` (§2.7).
+- [ ] File-type homogeneity + profile-type match validation (§2.8).
+- [ ] `start_editing` sends `Content-Type: ""` (§4 step 3).
+- [ ] `quick_edit` aborts when zero uploads succeed (§4).
+- [ ] I2I multipart: 64MB parts, ≤10000 parts, concurrency 4, memory bound, **abort-on-failure** (§7).
+- [ ] I2I completion via callback or download-link polling (no status endpoint) (§7).
+- [ ] `EditOptions` mutual-exclusivity enforced client-side, `null` fields omitted from payload (§9).
+- [ ] Typed returns for enhancement/copilot (`EnhanceResult`), finalize (`DownloadLinksList`), I2I edit trigger (`MessageResponse`), and single I2I link (`SingleDownloadLink`); models tolerate unknown extra fields (§6).
+
+> This checklist is the minimum bar for the **scenario/contract test suite**: each
+> item should map to at least one test that every language SDK runs against a
+> shared mock server.

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -368,11 +368,12 @@ sequenceDiagram
     participant S3 as Object storage
     U->>API: 1. POST /i2i/projects/ (name?)
     API-->>U: project_uuid
-    alt small files
+    Note over U: 2. upload_i2i_images routes each file by size
+    alt file <= multipart_threshold (batched)
         U->>API: 2a. POST /i2i/projects/{uuid}/get_temporary_upload_links
         API-->>U: presigned links
-        U->>S3: PUT each file (concurrent)
-    else large file
+        U->>S3: PUT each small file (concurrent)
+    else file > multipart_threshold
         U->>API: 2b. POST /i2i/projects/{uuid}/multipart_uploads (file_name, part_count)
         API-->>U: upload_id, key, part URLs
         U->>S3: PUT each part (concurrent)
@@ -394,19 +395,40 @@ sequenceDiagram
 | Validate name | `GET /i2i/projects/is_valid_name?name=` | Returns bool; a 2xx with no explicit flag is treated as valid. |
 | Get one | `GET /i2i/projects/{uuid}?get_thumbnail=` | Returns a `ProjectListItem`. |
 
-### Upload — standard
+### Upload — auto-routed (recommended)
 
-`POST /i2i/projects/{uuid}/get_temporary_upload_links` then concurrent PUT
-(§2.5). Body uses `{ files_list, client_type }` (defaults `client_type = API`).
+`upload_i2i_images` is the single entry point for I2I uploads. Callers pass any
+mix of files and never choose an upload mechanism — each file is routed by size
+against `multipart_threshold` (default **64 MB**):
 
-Single-file link: `GET /i2i/projects/{uuid}/get_upload_link?file_name=`.
+- **At or below the threshold:** collected and uploaded as a batch — one
+  `POST /i2i/projects/{uuid}/get_temporary_upload_links` request (body
+  `{ files_list, client_type }`, default `client_type = API`) followed by a single
+  concurrent PUT per file (§2.5).
+- **Above the threshold:** uploaded via S3 multipart (see below). Each large file
+  is one independent multipart upload.
+
+Results from both paths are merged into one `UploadSummary` (`total`, `successful`,
+`failed`, per-file `results`); a failure on any one file is captured, not fatal
+(partial success, as in §2.5). `max_concurrent` bounds both the batch PUTs and the
+parts of a multipart file.
+
+> Multipart is **I2I-only** — the Regular `upload_images` flow (§4) has no
+> multipart path — which is why auto-routing lives in the I2I upload method.
+
+Single-file upload link (advanced): `GET /i2i/projects/{uuid}/get_upload_link?file_name=`.
 
 ### Upload — multipart (large files)
 
-For one large file, split into parts and upload each to its own presigned URL.
+Used automatically by `upload_i2i_images` for files above the threshold, and also
+exposed directly (`upload_i2i_file_multipart`) as an advanced escape hatch to force
+multipart for a single file. Splits the file into parts and uploads each to its own
+presigned URL.
 
 - **Part size:** default **64 MB** (S3 requires ≥ 5 MB per part except the last).
-- **Part count:** `ceil(file_size / part_size)`, minimum 1, range 1–10000.
+  If the file would exceed S3's 10,000-part cap at the chosen size, the part size
+  is grown automatically: `part_size = max(part_size, ceil(file_size / 10000))`.
+- **Part count:** `ceil(file_size / part_size)`, minimum 1, never above 10,000.
 - **Concurrency:** default **4** concurrent parts.
 - **Memory bound:** read each chunk *inside* the semaphore so peak memory is
   bounded to `max_concurrent × part_size`.

--- a/examples/enhancement_example.py
+++ b/examples/enhancement_example.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""
+AI enhancement & copilot example for the Imagen AI SDK (v1.1.0).
+
+Demonstrates discovering AI quick tools for an already-edited project, applying a tool
+and a natural-language copilot instruction to an image, and finalizing the project.
+
+Prerequisites:
+- The project must already be EXPORTED. The enhancement endpoints reject
+  not-yet-exported projects with "Project has not been exported yet."
+- Some accounts are restricted to "realistic" edits; generative tools and copilot
+  instructions classified as generative are rejected with
+  "Only realistic editing requests are supported."
+"""
+
+import asyncio
+import os
+
+from imagen_sdk import ImagenClient
+
+
+async def main():
+    api_key = os.getenv("IMAGEN_API_KEY", "your_api_key_here")
+
+    # An existing, already-edited project UUID (see list_projects() to find one).
+    project_uuid = os.getenv("IMAGEN_PROJECT_UUID", "your_project_uuid")
+    filename = os.getenv("IMAGEN_IMAGE_NAME", "IMG_0001.jpg")
+
+    async with ImagenClient(api_key) as client:
+        # 1. Discover available AI tools for this project.
+        tools = await client.get_ai_tools(project_uuid)
+        print(f"Available AI tools ({len(tools.prompts)}):")
+        for tool in tools.prompts:
+            print(f"  - {tool.enhancement_type}: {tool.label} (batch: {tool.enabled_for_batch})")
+
+        if not tools.prompts:
+            print("No AI tools available for this project.")
+            return
+
+        # 2. Apply the first available quick tool to an image.
+        tool_id = tools.prompts[0].enhancement_type
+        print(f"\nApplying tool '{tool_id}' to {filename}...")
+        result = await client.enhance_image(project_uuid, filename, tool_id=tool_id)
+        print(f"  status={result.status} version_id={result.version_id}")
+        print(f"  enhanced: {result.enhanced_image_url}")
+
+        # 3. Apply a natural-language instruction via the AI copilot.
+        print("Applying copilot instruction...")
+        copilot = await client.apply_copilot(project_uuid, filename, "add warm twilight lighting")
+        print(f"  status={copilot.status} -> {copilot.enhanced_image_url}")
+
+        # 4. Finalize: generate final download URLs, upscaling enhanced images.
+        print("Finalizing project...")
+        final = await client.finalize_project(project_uuid)
+        print(f"Done. {len(final.files_list)} file(s) ready for download.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/examples.py
+++ b/examples/examples.py
@@ -48,7 +48,7 @@ async def main():
         # Step 1: Create client
         print("📡 Creating Imagen AI client...")
         # For this example, we use a dev URL. Remove base_url for production.
-        async with ImagenClient(API_KEY, base_url="https://api-beta.imagen-ai.com/v1") as client:
+        async with ImagenClient(API_KEY, base_url="https://api.imagen-ai.com/v1") as client:
             # Step 2: Get available profiles
             print("\n📋 Fetching available profiles...")
             profiles = await client.get_profiles()

--- a/examples/i2i_example.py
+++ b/examples/i2i_example.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""
+Image-to-image (I2I) example for the Imagen AI SDK (v1.1.0).
+
+Demonstrates creating an I2I project, uploading images (standard and multipart),
+triggering editing, and downloading results.
+
+Note: the I2I API has no status endpoint. Completion is signalled via a callback_url
+or by polling get_i2i_download_links() until links are available.
+"""
+
+import asyncio
+import os
+from pathlib import Path
+
+from imagen_sdk import I2IEditOptions, ImagenClient
+
+
+async def main():
+    api_key = os.getenv("IMAGEN_API_KEY", "your_api_key_here")
+
+    photos = [str(p) for p in Path("./sample_photos").glob("*.jpg") if p.is_file()]
+    if not photos:
+        print("No .jpg files found in ./sample_photos.")
+        return
+
+    async with ImagenClient(api_key) as client:
+        project_uuid = await client.create_i2i_project("I2I Example Project")
+        print(f"Created I2I project: {project_uuid}")
+
+        # Standard concurrent upload for small files.
+        summary = await client.upload_i2i_images(project_uuid, photos)
+        print(f"Uploaded {summary.successful}/{summary.total} images")
+
+        # For a single large file, use multipart upload instead:
+        large_file = os.getenv("IMAGEN_LARGE_FILE")
+        if large_file and Path(large_file).is_file():
+            print(f"Multipart-uploading {large_file}...")
+            await client.upload_i2i_file_multipart(project_uuid, large_file)
+
+        # Trigger editing (no polling endpoint; use callback_url or poll downloads).
+        edit = await client.start_i2i_editing(project_uuid, I2IEditOptions(perspective_correction=True))
+        print(f"I2I editing triggered: {edit.message}")
+
+        # Poll for download links once editing has completed server-side.
+        links = await client.get_i2i_download_links(project_uuid)
+        if links:
+            await client.download_files(links, "i2i_output")
+            print(f"Downloaded {len(links)} files to ./i2i_output")
+        else:
+            print("No download links yet; editing may still be in progress.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/i2i_example.py
+++ b/examples/i2i_example.py
@@ -2,8 +2,12 @@
 """
 Image-to-image (I2I) example for the Imagen AI SDK (v1.1.0).
 
-Demonstrates creating an I2I project, uploading images (standard and multipart),
-triggering editing, and downloading results.
+Demonstrates creating an I2I project, uploading images, triggering editing, and
+downloading results.
+
+Uploads: just call upload_i2i_images() with whatever files you have. The SDK routes
+each file by size automatically -- small files use a single presigned PUT, files above
+multipart_threshold (default 64 MB) use chunked multipart upload. You never choose.
 
 Note: the I2I API has no status endpoint. Completion is signalled via a callback_url
 or by polling get_i2i_download_links() until links are available.
@@ -19,24 +23,22 @@ from imagen_sdk import I2IEditOptions, ImagenClient
 async def main():
     api_key = os.getenv("IMAGEN_API_KEY", "your_api_key_here")
 
-    photos = [str(p) for p in Path("./sample_photos").glob("*.jpg") if p.is_file()]
+    # Any mix of small and large files -- routing is handled for you.
+    photos = [str(p) for p in Path("./sample_photos").glob("*.*") if p.is_file()]
     if not photos:
-        print("No .jpg files found in ./sample_photos.")
+        print("No files found in ./sample_photos.")
         return
 
     async with ImagenClient(api_key) as client:
         project_uuid = await client.create_i2i_project("I2I Example Project")
         print(f"Created I2I project: {project_uuid}")
 
-        # Standard concurrent upload for small files.
+        # One call for every file; small -> single PUT, large -> multipart, transparently.
         summary = await client.upload_i2i_images(project_uuid, photos)
         print(f"Uploaded {summary.successful}/{summary.total} images")
-
-        # For a single large file, use multipart upload instead:
-        large_file = os.getenv("IMAGEN_LARGE_FILE")
-        if large_file and Path(large_file).is_file():
-            print(f"Multipart-uploading {large_file}...")
-            await client.upload_i2i_file_multipart(project_uuid, large_file)
+        for r in summary.results:
+            if not r.success:
+                print(f"  failed: {r.file} -> {r.error}")
 
         # Trigger editing (no polling endpoint; use callback_url or poll downloads).
         edit = await client.start_i2i_editing(project_uuid, I2IEditOptions(perspective_correction=True))

--- a/examples/project_management_example.py
+++ b/examples/project_management_example.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""
+Project management example for the Imagen AI SDK (v1.1.0).
+
+Demonstrates listing projects with pagination, retrieving a single project,
+resolving a project name to its UUID, and listing sky replacement templates.
+"""
+
+import asyncio
+import os
+
+from imagen_sdk import ImagenClient
+
+
+async def main():
+    api_key = os.getenv("IMAGEN_API_KEY", "your_api_key_here")
+
+    async with ImagenClient(api_key) as client:
+        # List projects (paginated).
+        listing = await client.list_projects(size=10, page=0)
+        print(f"{listing.pagination.total} projects total; showing {len(listing.projects)}:")
+        for project in listing.projects:
+            print(f"  - {project.project_uuid} | {project.name} | {project.status} | {project.number_of_images} imgs")
+
+        if listing.projects:
+            # Retrieve a single project by UUID.
+            first = listing.projects[0]
+            detail = await client.get_project(first.project_uuid)
+            print(f"\nProject detail: {detail.name} created at {detail.created_at}")
+
+            # Resolve a project name to its UUID.
+            if detail.name:
+                resolved = await client.get_project_uuid(detail.name)
+                print(f"Resolved '{detail.name}' -> {resolved}")
+
+        # List sky replacement templates (use a template id in EditOptions).
+        templates = await client.get_sky_replacement_templates()
+        print(f"\n{len(templates)} sky replacement templates available.")
+        default = next((t for t in templates if t.is_default), None)
+        if default:
+            print(f"Default template id: {default.id}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/imagen_sdk/__init__.py
+++ b/imagen_sdk/__init__.py
@@ -58,7 +58,13 @@ One-Line Usage:
     print(f"Exported files: {result.exported_files}")
 """
 
-from .enums import CropAspectRatio, PhotographyType
+from .enums import (
+    ClientType,
+    CropAspectRatio,
+    DNGCompression,
+    PhotographyType,
+    ProjectSource,
+)
 from .exceptions import (
     AuthenticationError,
     DownloadError,
@@ -72,16 +78,34 @@ from .imagen_sdk import (
     SUPPORTED_FILE_FORMATS,
     ImagenClient,
     check_files_match_profile_type,
+    get_ai_tools,
     get_profile,
     get_profiles,
+    get_sky_replacement_templates,
+    list_projects,
     quick_edit,
 )
 from .models import (
+    AITool,
+    AIToolsResponse,
+    CompleteMultipartUploadRequest,
+    CopilotRequest,
+    CreateFilesUploadLinksRequest,
+    CreateMultipartUploadLinksRequest,
     DownloadLink,
     DownloadLinksList,
     DownloadLinksResponse,
     EditOptions,
+    EnhanceImageRequest,
+    EnhanceResult,
+    FileDownloadInfo,
     FileUploadInfo,
+    FinalizeProjectRequest,
+    I2IEditOptions,
+    MessageResponse,
+    MultipartUploadLinksResponse,
+    MultipartUploadPartUrl,
+    PaginationInfo,
     PresignedUrl,
     PresignedUrlList,
     PresignedUrlResponse,
@@ -90,15 +114,22 @@ from .models import (
     ProfileApiResponse,
     ProjectCreationResponse,
     ProjectCreationResponseData,
+    ProjectListItem,
+    ProjectListResponse,
     QuickEditResult,
+    ResetCopilotRequest,
+    SingleDownloadLink,
+    SkyTemplate,
+    SkyTemplatesResponse,
     StatusDetails,
     StatusResponse,
+    TemporaryFileUploadData,
     UploadResult,
     UploadSummary,
 )
 
 # Version info
-__version__ = "1.0.0"
+__version__ = "1.1.0"
 __author__ = "Shahar Polak"
 __email__ = "shahar@imagen-ai.com"
 __description__ = "A robust, Pydantic-powered SDK for the Imagen AI photo editing workflow"
@@ -125,16 +156,48 @@ __all__ = [
     "DownloadLink",
     "DownloadLinksList",
     "DownloadLinksResponse",
+    # New models (v1.1.0)
+    "AITool",
+    "AIToolsResponse",
+    "EnhanceResult",
+    "MessageResponse",
+    "SingleDownloadLink",
+    "SkyTemplate",
+    "SkyTemplatesResponse",
+    "PaginationInfo",
+    "ProjectListItem",
+    "ProjectListResponse",
+    "TemporaryFileUploadData",
+    "FileDownloadInfo",
+    "EnhanceImageRequest",
+    "CopilotRequest",
+    "ResetCopilotRequest",
+    "FinalizeProjectRequest",
+    "I2IEditOptions",
+    "CreateFilesUploadLinksRequest",
+    "CreateMultipartUploadLinksRequest",
+    "MultipartUploadPartUrl",
+    "MultipartUploadLinksResponse",
+    "CompleteMultipartUploadRequest",
+    # Exceptions
     "ImagenError",
     "AuthenticationError",
     "ProjectError",
     "UploadError",
     "DownloadError",
+    # Enums
     "PhotographyType",
     "CropAspectRatio",
+    "DNGCompression",
+    "ProjectSource",
+    "ClientType",
+    # Convenience functions
     "quick_edit",
     "get_profiles",
     "get_profile",
+    "get_sky_replacement_templates",
+    "list_projects",
+    "get_ai_tools",
     "check_files_match_profile_type",
     "RAW_EXTENSIONS",
     "JPG_EXTENSIONS",

--- a/imagen_sdk/_core.py
+++ b/imagen_sdk/_core.py
@@ -1,0 +1,58 @@
+"""
+Internal typing stubs shared by the ImagenClient feature mixins.
+
+At runtime this class is intentionally empty — the real implementations live on
+``ImagenClient`` in ``imagen_sdk.py``. The declarations below exist only for static
+type checking so that the feature mixins can reference the core client internals
+(``_make_request``, ``_unwrap``, upload helpers, etc.) without mypy errors.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, TypeVar
+
+from pydantic import BaseModel
+
+from .exceptions import ImagenError
+from .models import FileUploadInfo, UploadSummary
+
+_ModelT = TypeVar("_ModelT", bound=BaseModel)
+
+
+class _CoreClientMixin:
+    """Declares core client internals that feature mixins rely on (type-check only)."""
+
+    if TYPE_CHECKING:
+        _logger: logging.Logger
+        base_url: str
+
+        async def _make_request(self, method: str, endpoint: str, **kwargs: Any) -> dict[str, Any]: ...
+
+        @staticmethod
+        def _unwrap(payload: Any) -> Any: ...
+
+        def _parse_model(
+            self,
+            payload: Any,
+            model: type[_ModelT],
+            what: str,
+            error_type: type[ImagenError] = ImagenError,
+        ) -> _ModelT: ...
+
+        async def _prepare_upload_infos(
+            self, image_paths: list[str | Path], calculate_md5: bool
+        ) -> tuple[list[FileUploadInfo], list[Path]]: ...
+
+        async def _run_concurrent_uploads(
+            self,
+            valid_paths: list[Path],
+            upload_links_map: dict[str, str],
+            max_concurrent: int,
+            progress_callback: Callable[[int, int, str], None] | None = None,
+        ) -> UploadSummary: ...
+
+        @staticmethod
+        async def _upload_to_s3(file_path: Path, upload_url: str) -> None: ...

--- a/imagen_sdk/_enhancement.py
+++ b/imagen_sdk/_enhancement.py
@@ -1,0 +1,209 @@
+"""
+AI enhancement / copilot / finalize mixin for ImagenClient.
+
+Adds the per-image AI enhancement workflow:
+
+- get_ai_tools: list AI quick tools available for a project
+- enhance_image: apply an AI quick tool to an already-edited image
+- apply_copilot: apply a natural-language instruction via the AI copilot
+- reset_copilot: reset the copilot conversation history for an image
+- finalize_project: generate final download URLs, upscaling enhanced images
+
+Important behavior (verified against the API gateway):
+
+- **The whole enhancement pipeline requires an EXPORTED project.** ``get_ai_tools``,
+  ``enhance_image``, ``apply_copilot``, and ``finalize_project`` all reject projects
+  that have not finished exporting with ``400 "Project has not been exported yet."``
+  Run the standard edit-then-export flow first.
+- **Realistic-only accounts.** Some accounts/instructions are restricted to "realistic"
+  edits; generative requests (and copilot instructions classified as generative) are
+  rejected downstream with ``400 "Only realistic editing requests are supported."``
+  This gating is enforced by the editing service, not the gateway, so the SDK surfaces
+  it as an ``ImagenError``.
+"""
+
+from __future__ import annotations
+
+from ._core import _CoreClientMixin
+from .enums import ProjectSource
+from .models import (
+    AIToolsResponse,
+    CopilotRequest,
+    DownloadLinksList,
+    EnhanceImageRequest,
+    EnhanceResult,
+    FinalizeProjectRequest,
+    ResetCopilotRequest,
+)
+
+
+class EnhancementMixin(_CoreClientMixin):
+    """AI quick tools, copilot, and finalize operations."""
+
+    async def get_ai_tools(
+        self,
+        project_uuid: str,
+        project_source: ProjectSource = ProjectSource.REGULAR,
+    ) -> AIToolsResponse:
+        """
+        List the AI enhancement (quick) tools available for a project.
+
+        Args:
+            project_uuid: UUID of the project.
+            project_source: Project source (REGULAR or I2I, default REGULAR).
+
+        Returns:
+            AIToolsResponse whose ``prompts`` list contains the available tools. Use a
+            tool's ``enhancement_type`` as the ``tool_id`` for ``enhance_image``.
+
+        Note:
+            The project must already be exported, otherwise the API responds with
+            ``400 "Project has not been exported yet."``
+
+        Raises:
+            ImagenError: If the response cannot be parsed.
+        """
+        self._logger.debug(f"Listing AI tools for project {project_uuid} (source={project_source.value})")
+        response_json = await self._make_request(
+            "GET",
+            f"/projects/{project_uuid}/ai-tools",
+            params={"project_source": project_source.value},
+        )
+        return self._parse_model(response_json, AIToolsResponse, "AI tools response")
+
+    async def enhance_image(
+        self,
+        project_uuid: str,
+        filename: str,
+        tool_id: str,
+        parent_version_id: int | None = None,
+        project_source: ProjectSource = ProjectSource.REGULAR,
+    ) -> EnhanceResult:
+        """
+        Apply an AI quick tool to an already-edited image.
+
+        Args:
+            project_uuid: UUID of the project.
+            filename: Name of the image to enhance.
+            tool_id: Identifier of the AI quick tool (see ``get_ai_tools``).
+            parent_version_id: Optional version ID to base this enhancement on.
+            project_source: Project source (REGULAR or I2I, default REGULAR).
+
+        Returns:
+            EnhanceResult with the operation ``status``, ``version_id``, and
+            ``enhanced_image_url``.
+
+        Note:
+            Requires an exported project. Non-realistic edits may be rejected on
+            realistic-only accounts (see module docstring).
+
+        Raises:
+            ImagenError: If the response cannot be parsed.
+        """
+        request = EnhanceImageRequest(
+            tool_id=tool_id,
+            parent_version_id=parent_version_id,
+            project_source=project_source,
+        )
+        self._logger.info(f"Enhancing {filename} in project {project_uuid} with tool {tool_id}")
+        response_json = await self._make_request(
+            "POST",
+            f"/projects/{project_uuid}/images/{filename}/enhance",
+            json=request.to_api_dict(),
+        )
+        return self._parse_model(response_json, EnhanceResult, "enhance image response")
+
+    async def apply_copilot(
+        self,
+        project_uuid: str,
+        filename: str,
+        instruction: str,
+        parent_version_id: int | None = None,
+        project_source: ProjectSource = ProjectSource.REGULAR,
+    ) -> EnhanceResult:
+        """
+        Apply a natural-language editing instruction to an image via the AI copilot.
+
+        Args:
+            project_uuid: UUID of the project.
+            filename: Name of the image to edit.
+            instruction: Natural-language instruction (1-255 characters).
+            parent_version_id: Optional version ID to base this instruction on.
+            project_source: Project source (REGULAR or I2I, default REGULAR).
+
+        Returns:
+            EnhanceResult with the operation ``status``, ``version_id``, and
+            ``enhanced_image_url`` (same shape as ``enhance_image``).
+
+        Note:
+            Requires an exported project. Instructions classified as generative are
+            rejected on realistic-only accounts (see module docstring).
+
+        Raises:
+            ImagenError: If the response cannot be parsed.
+        """
+        request = CopilotRequest(
+            instruction=instruction,
+            parent_version_id=parent_version_id,
+            project_source=project_source,
+        )
+        self._logger.info(f"Applying copilot instruction to {filename} in project {project_uuid}")
+        response_json = await self._make_request(
+            "POST",
+            f"/projects/{project_uuid}/images/{filename}/copilot",
+            json=request.to_api_dict(),
+        )
+        return self._parse_model(response_json, EnhanceResult, "copilot response")
+
+    async def reset_copilot(
+        self,
+        project_uuid: str,
+        filename: str,
+        project_source: ProjectSource = ProjectSource.REGULAR,
+    ) -> None:
+        """
+        Reset the copilot conversation history for an image.
+
+        Args:
+            project_uuid: UUID of the project.
+            filename: Name of the image whose copilot history should be reset.
+            project_source: Project source (REGULAR or I2I, default REGULAR).
+        """
+        request = ResetCopilotRequest(project_source=project_source)
+        self._logger.info(f"Resetting copilot history for {filename} in project {project_uuid}")
+        await self._make_request(
+            "DELETE",
+            f"/projects/{project_uuid}/images/{filename}/copilot",
+            json=request.to_api_dict(),
+        )
+
+    async def finalize_project(
+        self,
+        project_uuid: str,
+        project_source: ProjectSource = ProjectSource.REGULAR,
+    ) -> DownloadLinksList:
+        """
+        Generate final download URLs for all images, upscaling enhanced ones.
+
+        Args:
+            project_uuid: UUID of the project.
+            project_source: Project source (REGULAR or I2I, default REGULAR).
+
+        Returns:
+            DownloadLinksList whose ``files_list`` holds the final per-file download links.
+
+        Note:
+            Requires an exported project, otherwise the API responds with
+            ``400 "Project has not been exported yet."``
+
+        Raises:
+            ImagenError: If the response cannot be parsed.
+        """
+        request = FinalizeProjectRequest(project_source=project_source)
+        self._logger.info(f"Finalizing project {project_uuid} (source={project_source.value})")
+        response_json = await self._make_request(
+            "POST",
+            f"/projects/{project_uuid}/finalize",
+            json=request.to_api_dict(),
+        )
+        return self._parse_model(response_json, DownloadLinksList, "finalize project response")

--- a/imagen_sdk/_i2i.py
+++ b/imagen_sdk/_i2i.py
@@ -1,0 +1,398 @@
+"""
+Image-to-image (I2I) mixin for ImagenClient.
+
+Adds the full ``/v1/i2i/...`` project family:
+
+- create_i2i_project / list_i2i_projects / validate_i2i_project_name / get_i2i_project
+- upload_i2i_images (reuses the shared concurrent-upload helpers)
+- multipart uploads for large files: create / complete / abort, plus the high-level
+  upload_i2i_file_multipart helper
+- start_i2i_editing (trigger only; there is no I2I status endpoint, completion is
+  signalled via callback_url or by download links becoming available)
+- get_i2i_download_links / get_i2i_download_link / get_i2i_upload_link
+"""
+
+from __future__ import annotations
+
+import asyncio
+import math
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import aiofiles
+import httpx
+
+from ._core import _CoreClientMixin
+from .exceptions import ProjectError, UploadError
+from .models import (
+    CompleteMultipartUploadRequest,
+    CreateFilesUploadLinksRequest,
+    CreateMultipartUploadLinksRequest,
+    DownloadLinksList,
+    I2IEditOptions,
+    MessageResponse,
+    MultipartUploadLinksResponse,
+    PresignedUrlList,
+    ProjectCreationResponseData,
+    ProjectListItem,
+    ProjectListResponse,
+    SingleDownloadLink,
+    TemporaryFileUploadData,
+    UploadSummary,
+)
+
+# S3 multipart part size: 64 MB (must be >= 5 MB except for the final part).
+DEFAULT_MULTIPART_PART_SIZE = 64 * 1024 * 1024
+
+
+class I2IMixin(_CoreClientMixin):
+    """Image-to-image project creation, uploads (incl. multipart), editing, and downloads."""
+
+    # -- Project lifecycle ----------------------------------------------------
+
+    async def create_i2i_project(self, name: str | None = None) -> str:
+        """
+        Create a new image-to-image (I2I) project.
+
+        Args:
+            name: Optional unique project name. A UUID is generated server-side if omitted.
+
+        Returns:
+            The created project's UUID.
+
+        Raises:
+            ProjectError: If the response cannot be parsed.
+        """
+        data: dict[str, Any] = {}
+        if name:
+            data["name"] = name
+
+        self._logger.info(f"Creating I2I project: {name or 'Unnamed'}")
+        response_json = await self._make_request("POST", "/i2i/projects/", json=data)
+        project_uuid = self._parse_model(
+            response_json, ProjectCreationResponseData, "I2I project creation response", ProjectError
+        ).project_uuid
+        self._logger.info(f"Created I2I project with UUID: {project_uuid}")
+        return project_uuid
+
+    async def list_i2i_projects(
+        self,
+        size: int = 20,
+        page: int = 0,
+        is_archived: bool | None = False,
+    ) -> ProjectListResponse:
+        """
+        List I2I projects with pagination.
+
+        Args:
+            size: Page size (1-100, default 20).
+            page: Zero-based page index (default 0).
+            is_archived: Filter by archived state, or None for all (default False).
+
+        Returns:
+            ProjectListResponse with the page of projects and pagination metadata.
+            Ordering is defined by the API, not the SDK; in practice projects come
+            back newest-first, so page 0 holds your most recently created projects.
+        """
+        params: dict[str, object] = {"size": size, "page": page}
+        if is_archived is not None:
+            params["is_archived"] = is_archived
+
+        self._logger.debug(f"Listing I2I projects (page={page}, size={size})")
+        response_json = await self._make_request("GET", "/i2i/projects", params=params)
+        return self._parse_model(response_json, ProjectListResponse, "I2I project list response", ProjectError)
+
+    async def validate_i2i_project_name(self, name: str) -> bool:
+        """
+        Check whether an I2I project name is valid/available.
+
+        Args:
+            name: The candidate project name.
+
+        Returns:
+            True if the name is valid/available, False otherwise. A successful (2xx)
+            response with no explicit flag is treated as valid.
+        """
+        self._logger.debug(f"Validating I2I project name: {name}")
+        response_json = await self._make_request("GET", "/i2i/projects/is_valid_name", params={"name": name})
+        data = self._unwrap(response_json)
+        if isinstance(data, bool):
+            return data
+        if isinstance(data, dict):
+            for key in ("is_valid", "valid"):
+                if key in data:
+                    return bool(data[key])
+        return True
+
+    async def get_i2i_project(self, project_uuid: str, get_thumbnail: bool = True) -> ProjectListItem:
+        """
+        Get a single I2I project by UUID.
+
+        Args:
+            project_uuid: UUID of the I2I project.
+            get_thumbnail: Whether to include the thumbnail URL (default True).
+
+        Returns:
+            ProjectListItem describing the project.
+        """
+        self._logger.debug(f"Getting I2I project {project_uuid}")
+        response_json = await self._make_request("GET", f"/i2i/projects/{project_uuid}", params={"get_thumbnail": get_thumbnail})
+        return self._parse_model(response_json, ProjectListItem, "I2I project response", ProjectError)
+
+    # -- Uploads --------------------------------------------------------------
+
+    async def upload_i2i_images(
+        self,
+        project_uuid: str,
+        image_paths: list[str | Path],
+        max_concurrent: int = 5,
+        calculate_md5: bool = False,
+        progress_callback: Callable[[int, int, str], None] | None = None,
+    ) -> UploadSummary:
+        """
+        Upload images to an I2I project concurrently.
+
+        Mirrors ``upload_images`` but targets the I2I upload-link endpoint. For very
+        large files use ``upload_i2i_file_multipart`` instead.
+
+        Args:
+            project_uuid: UUID of the I2I project.
+            image_paths: Local image file paths to upload.
+            max_concurrent: Maximum concurrent uploads (default 5).
+            calculate_md5: Whether to compute MD5 hashes for integrity (default False).
+            progress_callback: Optional progress callback (index, total, file path).
+
+        Returns:
+            UploadSummary with per-file results and aggregate counts.
+        """
+        if max_concurrent < 1:
+            raise ValueError("max_concurrent must be at least 1")
+
+        self._logger.info(f"Starting I2I upload of {len(image_paths)} images to project {project_uuid}")
+        files_to_upload, valid_paths = await self._prepare_upload_infos(image_paths, calculate_md5)
+
+        upload_request = CreateFilesUploadLinksRequest(files_list=files_to_upload)
+        response_json = await self._make_request(
+            "POST",
+            f"/i2i/projects/{project_uuid}/get_temporary_upload_links",
+            json=upload_request.to_api_dict(),
+        )
+        upload_links = self._parse_model(response_json, PresignedUrlList, "I2I presigned URL response", UploadError)
+        upload_links_map = {url.file_name: url.upload_link for url in upload_links.files_list}
+        return await self._run_concurrent_uploads(valid_paths, upload_links_map, max_concurrent, progress_callback)
+
+    async def get_i2i_upload_link(self, project_uuid: str, file_name: str) -> TemporaryFileUploadData:
+        """
+        Get a presigned upload link for a single I2I output image.
+
+        Args:
+            project_uuid: UUID of the I2I project.
+            file_name: Output image file name.
+
+        Returns:
+            TemporaryFileUploadData with the file name and presigned upload link.
+        """
+        self._logger.debug(f"Getting I2I upload link for {file_name} in {project_uuid}")
+        response_json = await self._make_request("GET", f"/i2i/projects/{project_uuid}/get_upload_link", params={"file_name": file_name})
+        return self._parse_model(response_json, TemporaryFileUploadData, "I2I upload link response", ProjectError)
+
+    # -- Multipart uploads ----------------------------------------------------
+
+    async def create_i2i_multipart_upload(self, project_uuid: str, file_name: str, part_count: int) -> MultipartUploadLinksResponse:
+        """
+        Initiate a multipart upload and obtain presigned URLs for each part.
+
+        Args:
+            project_uuid: UUID of the I2I project.
+            file_name: Name of the file to upload.
+            part_count: Number of parts (1-10000).
+
+        Returns:
+            MultipartUploadLinksResponse with the upload ID, storage key, and part URLs.
+        """
+        request = CreateMultipartUploadLinksRequest(file_name=file_name, part_count=part_count)
+        self._logger.debug(f"Creating multipart upload for {file_name} ({part_count} parts) in {project_uuid}")
+        response_json = await self._make_request(
+            "POST",
+            f"/i2i/projects/{project_uuid}/multipart_uploads",
+            json=request.to_api_dict(),
+        )
+        return self._parse_model(response_json, MultipartUploadLinksResponse, "multipart upload links response", UploadError)
+
+    async def complete_i2i_multipart_upload(self, project_uuid: str, upload_id: str, file_name: str) -> None:
+        """
+        Complete a multipart upload after all parts have been uploaded.
+
+        Args:
+            project_uuid: UUID of the I2I project.
+            upload_id: Multipart upload ID from ``create_i2i_multipart_upload``.
+            file_name: Name of the uploaded file.
+        """
+        request = CompleteMultipartUploadRequest(file_name=file_name)
+        self._logger.debug(f"Completing multipart upload {upload_id} for {file_name} in {project_uuid}")
+        await self._make_request(
+            "POST",
+            f"/i2i/projects/{project_uuid}/multipart_uploads/{upload_id}/complete",
+            json=request.to_api_dict(),
+        )
+
+    async def abort_i2i_multipart_upload(self, project_uuid: str, upload_id: str, key: str) -> None:
+        """
+        Abort an in-progress multipart upload.
+
+        Args:
+            project_uuid: UUID of the I2I project.
+            upload_id: Multipart upload ID from ``create_i2i_multipart_upload``.
+            key: Storage key from ``create_i2i_multipart_upload``.
+        """
+        # The body is sent via the `content`/`json` of a DELETE request.
+        self._logger.debug(f"Aborting multipart upload {upload_id} in {project_uuid}")
+        await self._make_request(
+            "DELETE",
+            f"/i2i/projects/{project_uuid}/multipart_uploads/{upload_id}",
+            json={"key": key},
+        )
+
+    async def upload_i2i_file_multipart(
+        self,
+        project_uuid: str,
+        file_path: str | Path,
+        part_size: int = DEFAULT_MULTIPART_PART_SIZE,
+        max_concurrent: int = 4,
+    ) -> MultipartUploadLinksResponse:
+        """
+        Upload a single large file to an I2I project using multipart upload.
+
+        Splits the file into ``part_size`` chunks, uploads each part to its presigned
+        URL concurrently, then completes the multipart upload. On any failure the
+        upload is aborted before the error is re-raised.
+
+        Args:
+            project_uuid: UUID of the I2I project.
+            file_path: Local path of the file to upload.
+            part_size: Bytes per part (default 64 MB; S3 requires >= 5 MB except the last part).
+            max_concurrent: Maximum concurrent part uploads (default 4).
+
+        Returns:
+            The MultipartUploadLinksResponse used for the upload.
+
+        Raises:
+            UploadError: If the file is missing/invalid or any part fails to upload.
+        """
+        if max_concurrent < 1:
+            raise ValueError("max_concurrent must be at least 1")
+
+        path = Path(file_path)
+        if not path.exists() or not path.is_file():
+            raise UploadError(f"File not found for multipart upload: {path}")
+
+        file_size = path.stat().st_size
+        part_count = max(1, math.ceil(file_size / part_size))
+        self._logger.info(f"Multipart-uploading {path.name} ({file_size} bytes, {part_count} parts) to {project_uuid}")
+
+        links = await self.create_i2i_multipart_upload(project_uuid, path.name, part_count)
+
+        semaphore = asyncio.Semaphore(max_concurrent)
+
+        async def upload_part(http_client: httpx.AsyncClient, part) -> None:
+            # Read inside the semaphore so at most max_concurrent chunks are held in
+            # memory at once (bounds peak memory to max_concurrent * part_size).
+            async with semaphore:
+                offset = (part.part_number - 1) * part_size
+                async with aiofiles.open(path, "rb") as f:
+                    await f.seek(offset)
+                    chunk = await f.read(part_size)
+                response = await http_client.put(part.upload_url, content=chunk)
+                response.raise_for_status()
+            self._logger.debug(f"Uploaded part {part.part_number}/{part_count} of {path.name}")
+
+        try:
+            # Reuse a single client across all parts so the connection pool is shared.
+            async with httpx.AsyncClient(timeout=300.0) as http_client:
+                await asyncio.gather(*(upload_part(http_client, part) for part in links.parts))
+            await self.complete_i2i_multipart_upload(project_uuid, links.upload_id, path.name)
+        except Exception as e:
+            self._logger.error(f"Multipart upload of {path.name} failed: {e}; aborting upload {links.upload_id}")
+            try:
+                await self.abort_i2i_multipart_upload(project_uuid, links.upload_id, links.key)
+            except Exception as abort_error:
+                self._logger.error(f"Failed to abort multipart upload {links.upload_id}: {abort_error}")
+            raise UploadError(f"Multipart upload of {path.name} failed: {e}")
+
+        self._logger.info(f"Completed multipart upload of {path.name}")
+        return links
+
+    # -- Editing & downloads --------------------------------------------------
+
+    async def start_i2i_editing(
+        self,
+        project_uuid: str,
+        edit_options: I2IEditOptions | None = None,
+    ) -> MessageResponse:
+        """
+        Trigger image-to-image editing for a project.
+
+        Unlike the standard edit flow, the I2I API exposes no status endpoint, so this
+        method only triggers the edit and returns immediately. Completion is signalled
+        via ``callback_url`` (if provided in ``edit_options``) or by polling
+        ``get_i2i_download_links`` until links are available (it returns
+        ``400 "...status In Progress."`` while the edit is still running).
+
+        Args:
+            project_uuid: UUID of the I2I project.
+            edit_options: Optional I2I editing parameters (hdr_merge, sky_replacement,
+                sky_replacement_template_id, perspective_correction, callback_url).
+
+        Returns:
+            MessageResponse with a human-readable confirmation ``message``.
+
+        Raises:
+            ImagenError: If the response cannot be parsed.
+        """
+        edit_data = edit_options.to_api_dict() if edit_options else {}
+        self._logger.info(f"Triggering I2I edit for project {project_uuid}")
+        response_json = await self._make_request(
+            "POST",
+            f"/i2i/projects/{project_uuid}/edit",
+            json=edit_data,
+        )
+        return self._parse_model(response_json, MessageResponse, "I2I edit trigger response", ProjectError)
+
+    async def get_i2i_download_links(self, project_uuid: str) -> list[str]:
+        """
+        Get download links for all images in an I2I project.
+
+        Args:
+            project_uuid: UUID of the I2I project.
+
+        Returns:
+            List of temporary download URLs.
+
+        Raises:
+            ProjectError: If the response cannot be parsed.
+        """
+        self._logger.debug(f"Getting I2I download links for project {project_uuid}")
+        response_json = await self._make_request("GET", f"/i2i/projects/{project_uuid}/get_temporary_download_links")
+        links_list = self._parse_model(response_json, DownloadLinksList, "I2I download links response", ProjectError)
+        links = [link.download_link for link in links_list.files_list]
+        self._logger.info(f"Retrieved {len(links)} I2I download links")
+        return links
+
+    async def get_i2i_download_link(self, project_uuid: str, file_name: str) -> SingleDownloadLink:
+        """
+        Get the download link for a single I2I output image.
+
+        Args:
+            project_uuid: UUID of the I2I project.
+            file_name: Name of the file to download.
+
+        Returns:
+            SingleDownloadLink with the temporary ``download_link``.
+
+        Raises:
+            ImagenError: If the response cannot be parsed.
+        """
+        self._logger.debug(f"Getting I2I download link for {file_name} in {project_uuid}")
+        response_json = await self._make_request("GET", f"/i2i/projects/{project_uuid}/get_download_link", params={"file_name": file_name})
+        return self._parse_model(response_json, SingleDownloadLink, "I2I download link response", ProjectError)

--- a/imagen_sdk/_i2i.py
+++ b/imagen_sdk/_i2i.py
@@ -1,12 +1,18 @@
 """
 Image-to-image (I2I) mixin for ImagenClient.
 
+I2I is a separate project type that takes input images and produces transformed
+output images (e.g. HDR merge, sky replacement, perspective correction), distinct
+from the classic RAW/JPG cull-edit-export workflow.
+
 Adds the full ``/v1/i2i/...`` project family:
 
 - create_i2i_project / list_i2i_projects / validate_i2i_project_name / get_i2i_project
-- upload_i2i_images (reuses the shared concurrent-upload helpers)
-- multipart uploads for large files: create / complete / abort, plus the high-level
-  upload_i2i_file_multipart helper
+- upload_i2i_images: the recommended upload entry point; routes each file by size
+  (small -> single PUT, large -> multipart) so callers never choose a method
+- multipart upload primitives for large files: create / complete / abort, plus the
+  high-level upload_i2i_file_multipart helper (used by upload_i2i_images, also public
+  as an advanced escape hatch)
 - start_i2i_editing (trigger only; there is no I2I status endpoint, completion is
   signalled via callback_url or by download links becoming available)
 - get_i2i_download_links / get_i2i_download_link / get_i2i_upload_link
@@ -30,6 +36,7 @@ from .models import (
     CreateFilesUploadLinksRequest,
     CreateMultipartUploadLinksRequest,
     DownloadLinksList,
+    FileUploadInfo,
     I2IEditOptions,
     MessageResponse,
     MultipartUploadLinksResponse,
@@ -39,6 +46,7 @@ from .models import (
     ProjectListResponse,
     SingleDownloadLink,
     TemporaryFileUploadData,
+    UploadResult,
     UploadSummary,
 )
 
@@ -149,22 +157,36 @@ class I2IMixin(_CoreClientMixin):
         max_concurrent: int = 5,
         calculate_md5: bool = False,
         progress_callback: Callable[[int, int, str], None] | None = None,
+        multipart_threshold: int = DEFAULT_MULTIPART_PART_SIZE,
     ) -> UploadSummary:
         """
-        Upload images to an I2I project concurrently.
+        Upload images to an I2I project, picking the right mechanism per file.
 
-        Mirrors ``upload_images`` but targets the I2I upload-link endpoint. For very
-        large files use ``upload_i2i_file_multipart`` instead.
+        This is the recommended I2I upload entry point: each file is routed
+        automatically based on its size, so callers never choose an upload method.
+
+        - Files at or below ``multipart_threshold`` are batched into a single
+          ``get_temporary_upload_links`` request and uploaded concurrently with a
+          single presigned PUT each.
+        - Files above the threshold are uploaded with S3 multipart
+          (``upload_i2i_file_multipart``), which chunks the file and is resilient on
+          large/slow transfers.
+
+        Multipart is only available for I2I projects (the standard ``upload_images``
+        flow has no multipart option), which is why auto-routing lives here.
 
         Args:
             project_uuid: UUID of the I2I project.
             image_paths: Local image file paths to upload.
-            max_concurrent: Maximum concurrent uploads (default 5).
+            max_concurrent: Maximum concurrent uploads / parts (default 5).
             calculate_md5: Whether to compute MD5 hashes for integrity (default False).
             progress_callback: Optional progress callback (index, total, file path).
+                Reported for the single-PUT batch; multipart files are reported once each.
+            multipart_threshold: Size in bytes above which a file uses multipart upload
+                (default 64 MB). Set higher to prefer single PUT, lower to chunk sooner.
 
         Returns:
-            UploadSummary with per-file results and aggregate counts.
+            UploadSummary with per-file results and aggregate counts across both paths.
         """
         if max_concurrent < 1:
             raise ValueError("max_concurrent must be at least 1")
@@ -172,15 +194,48 @@ class I2IMixin(_CoreClientMixin):
         self._logger.info(f"Starting I2I upload of {len(image_paths)} images to project {project_uuid}")
         files_to_upload, valid_paths = await self._prepare_upload_infos(image_paths, calculate_md5)
 
-        upload_request = CreateFilesUploadLinksRequest(files_list=files_to_upload)
-        response_json = await self._make_request(
-            "POST",
-            f"/i2i/projects/{project_uuid}/get_temporary_upload_links",
-            json=upload_request.to_api_dict(),
+        # Route each file by size: small -> batched single PUT, large -> multipart.
+        small_infos: list[FileUploadInfo] = []
+        small_paths: list[Path] = []
+        large_paths: list[Path] = []
+        for info, path in zip(files_to_upload, valid_paths):
+            if path.stat().st_size > multipart_threshold:
+                large_paths.append(path)
+            else:
+                small_infos.append(info)
+                small_paths.append(path)
+
+        results: list[UploadResult] = []
+
+        if small_paths:
+            upload_request = CreateFilesUploadLinksRequest(files_list=small_infos)
+            response_json = await self._make_request(
+                "POST",
+                f"/i2i/projects/{project_uuid}/get_temporary_upload_links",
+                json=upload_request.to_api_dict(),
+            )
+            upload_links = self._parse_model(response_json, PresignedUrlList, "I2I presigned URL response", UploadError)
+            upload_links_map = {url.file_name: url.upload_link for url in upload_links.files_list}
+            batch = await self._run_concurrent_uploads(small_paths, upload_links_map, max_concurrent, progress_callback)
+            results.extend(batch.results)
+
+        for path in large_paths:
+            self._logger.info(f"Routing large file to multipart upload: {path.name}")
+            try:
+                await self.upload_i2i_file_multipart(project_uuid, path, max_concurrent=max_concurrent)
+                results.append(UploadResult(file=str(path), success=True, error=None))
+            except Exception as e:
+                self._logger.error(f"Multipart upload failed for {path.name}: {e}")
+                results.append(UploadResult(file=str(path), success=False, error=str(e)))
+            if progress_callback:
+                progress_callback(len(results), len(valid_paths), str(path))
+
+        return UploadSummary(
+            total=len(results),
+            successful=sum(1 for r in results if r.success),
+            failed=sum(1 for r in results if not r.success),
+            results=results,
         )
-        upload_links = self._parse_model(response_json, PresignedUrlList, "I2I presigned URL response", UploadError)
-        upload_links_map = {url.file_name: url.upload_link for url in upload_links.files_list}
-        return await self._run_concurrent_uploads(valid_paths, upload_links_map, max_concurrent, progress_callback)
 
     async def get_i2i_upload_link(self, project_uuid: str, file_name: str) -> TemporaryFileUploadData:
         """
@@ -288,6 +343,9 @@ class I2IMixin(_CoreClientMixin):
             raise UploadError(f"File not found for multipart upload: {path}")
 
         file_size = path.stat().st_size
+        # S3 allows at most 10000 parts; grow part_size if needed to stay within that.
+        if file_size:
+            part_size = max(part_size, math.ceil(file_size / 10000))
         part_count = max(1, math.ceil(file_size / part_size))
         self._logger.info(f"Multipart-uploading {path.name} ({file_size} bytes, {part_count} parts) to {project_uuid}")
 

--- a/imagen_sdk/_projects.py
+++ b/imagen_sdk/_projects.py
@@ -1,0 +1,168 @@
+"""
+Project management mixin for ImagenClient.
+
+Adds read/listing endpoints and sky-replacement template discovery that were not
+part of the original SDK surface:
+
+- list_projects / get_project / get_project_uuid
+- get_sky_replacement_templates
+- get_export_upload_link / get_export_download_link
+"""
+
+from __future__ import annotations
+
+from ._core import _CoreClientMixin
+from .enums import ClientType
+from .exceptions import ImagenError, ProjectError
+from .models import (
+    FileDownloadInfo,
+    ProjectListItem,
+    ProjectListResponse,
+    SkyTemplate,
+    SkyTemplatesResponse,
+    TemporaryFileUploadData,
+)
+
+
+class ProjectManagementMixin(_CoreClientMixin):
+    """Project listing/retrieval, sky templates, and per-image export links."""
+
+    async def list_projects(
+        self,
+        size: int = 20,
+        page: int = 0,
+        client_type: ClientType = ClientType.API,
+        is_archived: bool | None = False,
+        get_thumbnail: bool = True,
+    ) -> ProjectListResponse:
+        """
+        List projects in your account with pagination.
+
+        Args:
+            size: Page size (1-100, default 20).
+            page: Zero-based page index (default 0).
+            client_type: Client type filter (default API).
+            is_archived: Filter by archived state, or None for all (default False).
+            get_thumbnail: Whether to include thumbnail URLs (default True).
+
+        Returns:
+            ProjectListResponse with the page of projects and pagination metadata.
+            Ordering is defined by the API, not the SDK; in practice projects come
+            back newest-first, so page 0 holds your most recently created projects
+            and higher pages walk back in time.
+
+        Raises:
+            ProjectError: If the response cannot be parsed.
+            AuthenticationError: If the API key is invalid.
+        """
+        params: dict[str, object] = {
+            "size": size,
+            "page": page,
+            "client_type": client_type.value,
+            "get_thumbnail": get_thumbnail,
+        }
+        if is_archived is not None:
+            params["is_archived"] = is_archived
+
+        self._logger.debug(f"Listing projects (page={page}, size={size})")
+        response_json = await self._make_request("GET", "/projects", params=params)
+        return self._parse_model(response_json, ProjectListResponse, "project list response", ProjectError)
+
+    async def get_project(self, project_uuid: str, get_thumbnail: bool = True) -> ProjectListItem:
+        """
+        Get a single project by its UUID.
+
+        Args:
+            project_uuid: UUID of the project.
+            get_thumbnail: Whether to include the thumbnail URL (default True).
+
+        Returns:
+            ProjectListItem describing the project.
+
+        Raises:
+            ProjectError: If the response cannot be parsed.
+        """
+        self._logger.debug(f"Getting project {project_uuid}")
+        response_json = await self._make_request("GET", f"/projects/{project_uuid}", params={"get_thumbnail": get_thumbnail})
+        return self._parse_model(response_json, ProjectListItem, "project response", ProjectError)
+
+    async def get_project_uuid(self, project_name: str) -> str:
+        """
+        Resolve a project name to its UUID.
+
+        Args:
+            project_name: The (unique) project name.
+
+        Returns:
+            The project's UUID.
+
+        Raises:
+            ProjectError: If the project cannot be found or the UUID cannot be extracted.
+        """
+        self._logger.debug(f"Resolving UUID for project name: {project_name}")
+        response_json = await self._make_request("GET", f"/projects/{project_name}/uuid")
+        data = self._unwrap(response_json)
+
+        # The response schema is unspecified server-side; accept the common shapes.
+        if isinstance(data, str):
+            return data
+        if isinstance(data, dict):
+            for key in ("project_uuid", "uuid"):
+                value = data.get(key)
+                if isinstance(value, str) and value:
+                    return value
+        raise ProjectError(f"Could not extract project UUID for name '{project_name}' from response: {data!r}")
+
+    async def get_sky_replacement_templates(self) -> list[SkyTemplate]:
+        """
+        List available sky replacement templates.
+
+        Use the returned ``id`` values for ``EditOptions.sky_replacement_template_id``.
+
+        Returns:
+            List of SkyTemplate entries.
+
+        Raises:
+            ImagenError: If the response cannot be parsed.
+        """
+        self._logger.debug("Getting sky replacement templates")
+        response_json = await self._make_request("GET", "/projects/sky_replacement/templates")
+        return self._parse_model(response_json, SkyTemplatesResponse, "sky replacement templates response", ImagenError).templates
+
+    async def get_export_upload_link(self, project_uuid: str, file_name: str) -> TemporaryFileUploadData:
+        """
+        Get a presigned upload link for a single exported image.
+
+        Args:
+            project_uuid: UUID of the project.
+            file_name: The exported image file name.
+
+        Returns:
+            TemporaryFileUploadData with the file name and presigned upload link.
+
+        Raises:
+            ProjectError: If the response cannot be parsed.
+        """
+        self._logger.debug(f"Getting export upload link for {file_name} in {project_uuid}")
+        response_json = await self._make_request("GET", f"/projects/{project_uuid}/export/get_upload_link", params={"file_name": file_name})
+        return self._parse_model(response_json, TemporaryFileUploadData, "export upload link response", ProjectError)
+
+    async def get_export_download_link(self, project_uuid: str, file_name: str) -> FileDownloadInfo:
+        """
+        Get a presigned download link for a single exported image.
+
+        Args:
+            project_uuid: UUID of the project.
+            file_name: The exported image file name.
+
+        Returns:
+            FileDownloadInfo with the file name and download link.
+
+        Raises:
+            ProjectError: If the response cannot be parsed.
+        """
+        self._logger.debug(f"Getting export download link for {file_name} in {project_uuid}")
+        response_json = await self._make_request(
+            "GET", f"/projects/{project_uuid}/export/get_download_link", params={"file_name": file_name}
+        )
+        return self._parse_model(response_json, FileDownloadInfo, "export download link response", ProjectError)

--- a/imagen_sdk/enums.py
+++ b/imagen_sdk/enums.py
@@ -14,6 +14,7 @@ class PhotographyType(Enum):
     FAMILY_NEWBORN = "FAMILY_NEWBORN"
     BOUDOIR = "BOUDOIR"
     SPORTS = "SPORTS"
+    SCHOOL = "SCHOOL"
 
 
 class CropAspectRatio(Enum):
@@ -22,3 +23,26 @@ class CropAspectRatio(Enum):
     RATIO_2X3 = "2X3"
     RATIO_4X5 = "4X5"
     RATIO_5X7 = "5X7"
+
+
+class DNGCompression(Enum):
+    """Compression mode for HDR-merged DNG output (from API spec)."""
+
+    LOSSY = "LOSSY"
+    LOSSLESS = "LOSSLESS"
+
+
+class ProjectSource(Enum):
+    """Project source for AI enhancement / copilot operations (from API spec)."""
+
+    REGULAR = "REGULAR"
+    I2I = "I2I"
+
+
+class ClientType(Enum):
+    """Client type used when creating projects / upload links (from API spec)."""
+
+    APP = "APP"
+    API = "API"
+    MOBILE = "MOBILE"
+    WEB_REAL_ESTATE = "WEB_REAL_ESTATE"

--- a/imagen_sdk/imagen_sdk.py
+++ b/imagen_sdk/imagen_sdk.py
@@ -11,13 +11,16 @@ import logging
 import time
 from collections.abc import Callable
 from pathlib import Path
-from typing import Any
+from typing import Any, TypeVar
 from urllib.parse import unquote, urlparse
 
 import aiofiles
 import httpx
-from pydantic import ValidationError
+from pydantic import BaseModel, ValidationError
 
+from ._enhancement import EnhancementMixin
+from ._i2i import I2IMixin
+from ._projects import ProjectManagementMixin
 from .enums import PhotographyType
 from .exceptions import (
     AuthenticationError,
@@ -27,22 +30,29 @@ from .exceptions import (
     UploadError,
 )
 from .models import (
-    DownloadLinksResponse,
+    AIToolsResponse,
+    DownloadLinksList,
     EditOptions,
     FileUploadInfo,
-    PresignedUrlResponse,
+    PresignedUrlList,
     Profile,
-    ProfileApiData,
-    ProjectCreationResponse,
+    ProfileApiResponse,
+    ProjectCreationResponseData,
+    ProjectListResponse,
     QuickEditResult,
+    SkyTemplate,
     StatusDetails,
-    StatusResponse,
     UploadResult,
     UploadSummary,
 )
 
 # Default logger for the SDK
 _default_logger = logging.getLogger("imagen_sdk.ImagenClient")
+
+# Single source of truth for the production API base URL.
+DEFAULT_BASE_URL = "https://api.imagen-ai.com/v1"
+
+_ModelT = TypeVar("_ModelT", bound=BaseModel)
 
 RAW_EXTENSIONS = {
     ".dng",
@@ -74,7 +84,7 @@ SUPPORTED_FILE_FORMATS = RAW_EXTENSIONS | JPG_EXTENSIONS
 # =============================================================================
 
 
-class ImagenClient:
+class ImagenClient(ProjectManagementMixin, EnhancementMixin, I2IMixin):
     """
     Main Imagen AI client for handling the complete photo editing workflow.
 
@@ -144,7 +154,7 @@ class ImagenClient:
     def __init__(
         self,
         api_key: str,
-        base_url: str = "https://api-beta.imagen-ai.com/v1",
+        base_url: str = DEFAULT_BASE_URL,
         logger: logging.Logger | None = None,
         logger_level: int | None = None,
     ):
@@ -198,7 +208,7 @@ class ImagenClient:
             self._session = httpx.AsyncClient(
                 headers={
                     "x-api-key": self.api_key,
-                    "User-Agent": "Imagen-Python-SDK/1.0.0",
+                    "User-Agent": "Imagen-Python-SDK/1.1.0",
                 },
                 timeout=httpx.Timeout(300.0),
             )
@@ -266,14 +276,7 @@ class ImagenClient:
 
             # Check for other client or server errors
             elif response.status_code >= 400:
-                try:
-                    # Try to parse a detailed error message from the JSON response
-                    error_data = response.json()
-                    message = error_data.get("detail", response.text)
-                except Exception:
-                    # Fallback to the raw response text if JSON parsing fails
-                    message = response.text
-
+                message = self._extract_error_message(response)
                 self._logger.error(f"API error {response.status_code}: {message}")
                 raise ImagenError(f"API Error ({response.status_code}): {message}")
 
@@ -286,6 +289,86 @@ class ImagenClient:
         except httpx.RequestError as e:
             self._logger.error(f"Request failed: {e}")
             raise ImagenError(f"Request failed: {e}")
+
+    @staticmethod
+    def _extract_error_message(response: httpx.Response) -> str:
+        """
+        Extract a human-readable error message from an error response.
+
+        The production API returns errors as ``{"error": {"message": ...}}``; older/other
+        responses may use ``{"detail": ...}``. This prefers ``error.message``, falls back
+        to ``detail``, and finally to the raw response text.
+
+        Args:
+            response: The httpx error response.
+
+        Returns:
+            The best available error message string.
+        """
+        try:
+            data = response.json()
+        except Exception:
+            return response.text
+
+        if isinstance(data, dict):
+            error = data.get("error")
+            if isinstance(error, dict) and error.get("message"):
+                return str(error["message"])
+            if isinstance(error, str) and error:
+                return error
+            if data.get("detail"):
+                return str(data["detail"])
+
+        return response.text
+
+    @staticmethod
+    def _unwrap(payload: Any) -> Any:
+        """
+        Return the inner body when the API wraps a response in a sole ``{"data": ...}`` envelope.
+
+        Production responses (https://api.imagen-ai.com/v1) return payloads at the root,
+        while legacy/beta responses wrapped the body in a single top-level ``data`` key.
+        This helper transparently supports both so existing parsers keep working.
+
+        Args:
+            payload: The parsed JSON response (typically a dict).
+
+        Returns:
+            The unwrapped inner payload if a sole ``data`` key is present, else the payload as-is.
+        """
+        if isinstance(payload, dict) and set(payload.keys()) == {"data"}:
+            return payload["data"]
+        return payload
+
+    def _parse_model(
+        self,
+        payload: Any,
+        model: type[_ModelT],
+        what: str,
+        error_type: type[ImagenError] = ImagenError,
+    ) -> _ModelT:
+        """
+        Unwrap the response envelope and validate it into a Pydantic model.
+
+        Centralizes the recurring ``model.model_validate(self._unwrap(payload))`` +
+        ValidationError handling used across all parse sites.
+
+        Args:
+            payload: The parsed JSON response.
+            model: The Pydantic model class to validate into.
+            what: Short description used in the error message (e.g. "download links response").
+            error_type: Exception type to raise on failure (default ImagenError).
+
+        Returns:
+            The validated model instance.
+
+        Raises:
+            error_type: If the payload cannot be validated.
+        """
+        try:
+            return model.model_validate(self._unwrap(payload))
+        except ValidationError as e:
+            raise error_type(f"Could not parse {what}: {e}")
 
     async def create_project(self, name: str | None = None) -> str:
         """
@@ -328,15 +411,9 @@ class ImagenClient:
         self._logger.info(f"Creating project: {name or 'Unnamed'}")
         response_json = await self._make_request("POST", "/projects/", json=data)
 
-        try:
-            # Validate the response and extract the UUID
-            project_response = ProjectCreationResponse.model_validate(response_json)
-            project_uuid = project_response.data.project_uuid
-            self._logger.info(f"Created project with UUID: {project_uuid}")
-            return project_uuid
-        except ValidationError as e:
-            self._logger.error(f"Failed to parse project creation response: {e}")
-            raise ProjectError(f"Could not parse project creation response: {e}")
+        project_data = self._parse_model(response_json, ProjectCreationResponseData, "project creation response", ProjectError)
+        self._logger.info(f"Created project with UUID: {project_data.project_uuid}")
+        return project_data.project_uuid
 
     async def upload_images(
         self,
@@ -406,6 +483,42 @@ class ImagenClient:
 
         self._logger.info(f"Starting upload of {len(image_paths)} images to project {project_uuid}")
 
+        files_to_upload, valid_paths = await self._prepare_upload_infos(image_paths, calculate_md5)
+
+        # Get presigned URLs from the API. The payload is built inline (rather than via
+        # CreateFilesUploadLinksRequest) to preserve the exact original request shape for
+        # backward compatibility; the server defaults client_type to "API".
+        upload_payload = {"files_list": [f.model_dump(exclude_none=True) for f in files_to_upload]}
+        response_json = await self._make_request(
+            "POST",
+            f"/projects/{project_uuid}/get_temporary_upload_links",
+            json=upload_payload,
+        )
+
+        upload_links = self._parse_model(response_json, PresignedUrlList, "presigned URL response", UploadError)
+
+        # Create a mapping of filenames to their upload URLs for easy access
+        upload_links_map = {url.file_name: url.upload_link for url in upload_links.files_list}
+
+        return await self._run_concurrent_uploads(valid_paths, upload_links_map, max_concurrent, progress_callback)
+
+    async def _prepare_upload_infos(
+        self,
+        image_paths: list[str | Path],
+        calculate_md5: bool,
+    ) -> tuple[list[FileUploadInfo], list[Path]]:
+        """
+        Validate local paths and build FileUploadInfo entries for upload-link requests.
+
+        Shared by `upload_images` and `upload_i2i_images`. Invalid paths are skipped
+        with a warning.
+
+        Returns:
+            Tuple of (file upload infos, validated local paths) in matching order.
+
+        Raises:
+            UploadError: If no valid local files are found.
+        """
         files_to_upload: list[FileUploadInfo] = []
         valid_paths: list[Path] = []
 
@@ -421,23 +534,31 @@ class ImagenClient:
         if not valid_paths:
             raise UploadError("No valid local files found to upload.")
 
-        # Get presigned URLs from the API
-        upload_payload = {"files_list": [f.model_dump(exclude_none=True) for f in files_to_upload]}
-        response_json = await self._make_request(
-            "POST",
-            f"/projects/{project_uuid}/get_temporary_upload_links",
-            json=upload_payload,
-        )
+        return files_to_upload, valid_paths
 
-        try:
-            upload_links_response = PresignedUrlResponse.model_validate(response_json)
-        except ValidationError as e:
-            raise UploadError(f"Could not parse presigned URL response: {e}")
+    async def _run_concurrent_uploads(
+        self,
+        valid_paths: list[Path],
+        upload_links_map: dict[str, str],
+        max_concurrent: int,
+        progress_callback: Callable[[int, int, str], None] | None = None,
+    ) -> UploadSummary:
+        """
+        Upload a set of local files concurrently to their presigned URLs.
 
-        # Create a mapping of filenames to their upload URLs for easy access
-        upload_links_map = {url.file_name: url.upload_link for url in upload_links_response.data.files_list}
+        Shared by both the standard (`upload_images`) and image-to-image
+        (`upload_i2i_images`) upload flows.
 
-        # Inner function to handle the upload of a single file
+        Args:
+            valid_paths: Local files to upload (already validated to exist).
+            upload_links_map: Mapping of file name -> presigned upload URL.
+            max_concurrent: Maximum number of concurrent uploads.
+            progress_callback: Optional progress callback (index, total, file path).
+
+        Returns:
+            UploadSummary with per-file results and aggregate counts.
+        """
+
         async def upload_single_file(file_path: Path, index: int) -> UploadResult:
             # Report progress before starting the upload
             if progress_callback:
@@ -607,15 +728,10 @@ class ImagenClient:
         """
         self._logger.debug(f"Getting download links for project {project_uuid}")
         response_json = await self._make_request("GET", f"/projects/{project_uuid}/edit/get_temporary_download_links")
-        try:
-            # Validate the full response structure
-            links_response = DownloadLinksResponse.model_validate(response_json)
-            # Access the list via .data and extract just the URL strings
-            links = [link.download_link for link in links_response.data.files_list]
-            self._logger.info(f"Retrieved {len(links)} download links")
-            return links
-        except ValidationError as e:
-            raise ProjectError(f"Could not parse download links response: {e}")
+        links_list = self._parse_model(response_json, DownloadLinksList, "download links response", ProjectError)
+        links = [link.download_link for link in links_list.files_list]
+        self._logger.info(f"Retrieved {len(links)} download links")
+        return links
 
     async def export_project(self, project_uuid: str) -> StatusDetails:
         """
@@ -699,15 +815,10 @@ class ImagenClient:
         """
         self._logger.debug(f"Getting export links for project {project_uuid}")
         response_json = await self._make_request("GET", f"/projects/{project_uuid}/export/get_temporary_download_links")
-        try:
-            # Validate the full response structure
-            links_response = DownloadLinksResponse.model_validate(response_json)
-            # Access the list via .data and extract just the URL strings
-            links = [link.download_link for link in links_response.data.files_list]
-            self._logger.info(f"Retrieved {len(links)} export links")
-            return links
-        except ValidationError as e:
-            raise ProjectError(f"Could not parse export links response: {e}")
+        links_list = self._parse_model(response_json, DownloadLinksList, "export links response", ProjectError)
+        links = [link.download_link for link in links_list.files_list]
+        self._logger.info(f"Retrieved {len(links)} export links")
+        return links
 
     async def download_files(
         self,
@@ -905,10 +1016,13 @@ class ImagenClient:
         self._logger.debug("Getting available profiles")
         response_json = await self._make_request("GET", "/profiles")
         try:
-            # Validate the full response structure
-            api_data = ProfileApiData.model_validate(response_json)
-            # Return the nested list of profiles
-            profiles = api_data.data.profiles
+            # Profiles come back either as a bare list (production) or wrapped in
+            # {"data": {"profiles": [...]}} (legacy). Normalize both shapes.
+            unwrapped = self._unwrap(response_json)
+            if isinstance(unwrapped, list):
+                profiles = [Profile.model_validate(p) for p in unwrapped]
+            else:
+                profiles = ProfileApiResponse.model_validate(unwrapped).profiles
             self._logger.info(f"Retrieved {len(profiles)} profiles")
             return profiles
         except ValidationError as e:
@@ -983,14 +1097,10 @@ class ImagenClient:
             endpoint = f"/projects/{project_uuid}/{operation}/status"
             status_json = await self._make_request("GET", endpoint)
 
-            try:
-                # Validate the full response, including the 'data' wrapper
-                status_response = StatusResponse.model_validate(status_json)
-            except ValidationError as e:
-                raise ProjectError(f"Could not parse status response for {operation}: {e}")
+            # Envelope-tolerant: handles both the legacy 'data' wrapper and the
+            # production unwrapped {status: ...} shape.
+            status_details = self._parse_model(status_json, StatusDetails, f"status response for {operation}", ProjectError)
 
-            # Access the actual status details through the .data attribute
-            status_details = status_response.data
             elapsed_int = int(elapsed)
 
             # Construct a progress string if progress data is available
@@ -1026,7 +1136,7 @@ class ImagenClient:
 # =============================================================================
 
 
-async def get_profiles(api_key: str, base_url: str = "https://api-beta.imagen-ai.com/v1") -> list[Profile]:
+async def get_profiles(api_key: str, base_url: str = DEFAULT_BASE_URL) -> list[Profile]:
     """
     Get available editing profiles using a standalone function.
 
@@ -1056,6 +1166,72 @@ async def get_profiles(api_key: str, base_url: str = "https://api-beta.imagen-ai
     """
     async with ImagenClient(api_key, base_url) as client:
         return await client.get_profiles()
+
+
+async def get_sky_replacement_templates(api_key: str, base_url: str = DEFAULT_BASE_URL) -> list[SkyTemplate]:
+    """
+    List available sky replacement templates using a standalone function.
+
+    Args:
+        api_key (str): Your Imagen AI API key
+        base_url (str): API base URL (default: production URL)
+
+    Returns:
+        List[SkyTemplate]: Available sky replacement templates (use ``id`` for
+                           ``EditOptions.sky_replacement_template_id``)
+
+    Example:
+        ```python
+        from imagen_sdk import get_sky_replacement_templates
+
+        templates = await get_sky_replacement_templates("your_api_key")
+        default_template = next((t for t in templates if t.is_default), templates[0])
+        ```
+    """
+    async with ImagenClient(api_key, base_url) as client:
+        return await client.get_sky_replacement_templates()
+
+
+async def list_projects(
+    api_key: str,
+    size: int = 20,
+    page: int = 0,
+    base_url: str = DEFAULT_BASE_URL,
+) -> ProjectListResponse:
+    """
+    List projects in your account using a standalone function.
+
+    Args:
+        api_key (str): Your Imagen AI API key
+        size (int): Page size (1-100, default 20)
+        page (int): Zero-based page index (default 0)
+        base_url (str): API base URL (default: production URL)
+
+    Returns:
+        ProjectListResponse: A page of projects plus pagination metadata
+    """
+    async with ImagenClient(api_key, base_url) as client:
+        return await client.list_projects(size=size, page=page)
+
+
+async def get_ai_tools(
+    api_key: str,
+    project_uuid: str,
+    base_url: str = DEFAULT_BASE_URL,
+) -> AIToolsResponse:
+    """
+    List AI enhancement tools for a project using a standalone function.
+
+    Args:
+        api_key (str): Your Imagen AI API key
+        project_uuid (str): UUID of the project
+        base_url (str): API base URL (default: production URL)
+
+    Returns:
+        AIToolsResponse whose ``prompts`` list contains the available tools.
+    """
+    async with ImagenClient(api_key, base_url) as client:
+        return await client.get_ai_tools(project_uuid)
 
 
 def check_files_match_profile_type(image_paths: list[str | Path], profile: Profile, logger: logging.Logger):
@@ -1142,7 +1318,7 @@ async def quick_edit(
     download: bool = False,
     download_dir: str | Path = "downloads",
     export_download_dir: str | Path | None = None,
-    base_url: str = "https://api-beta.imagen-ai.com/v1",
+    base_url: str = DEFAULT_BASE_URL,
     logger: logging.Logger | None = None,
     logger_level: int | None = None,
 ) -> QuickEditResult:
@@ -1273,7 +1449,7 @@ async def quick_edit(
         return result
 
 
-async def get_profile(api_key: str, profile_key: int, base_url: str = "https://api-beta.imagen-ai.com/v1") -> Profile:
+async def get_profile(api_key: str, profile_key: int, base_url: str = DEFAULT_BASE_URL) -> Profile:
     """
     Fetch a specific profile by its key.
 

--- a/imagen_sdk/models.py
+++ b/imagen_sdk/models.py
@@ -1,6 +1,8 @@
 from typing import Any
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from .enums import ClientType, DNGCompression, ProjectSource
 
 
 class Profile(BaseModel):
@@ -60,6 +62,11 @@ class EditOptions(BaseModel):
     window_pull: bool | None = Field(None, description="Whether to apply window pull")
     crop_aspect_ratio: str | None = Field(None, description="Custom aspect ratio for cropping")
 
+    callback_url: str | None = Field(None, description="Optional webhook URL called when editing completes")
+    hdr_output_compression: DNGCompression | None = Field(
+        None, description="Compression mode for HDR-merged DNG output (LOSSY or LOSSLESS)"
+    )
+
     @model_validator(mode="after")
     def check_mutual_exclusivity(self):
         # Enforce: crop, headshot_crop, portrait_crop are mutually exclusive
@@ -75,7 +82,7 @@ class EditOptions(BaseModel):
         return self
 
     def to_api_dict(self) -> dict[str, Any]:
-        return self.model_dump(exclude_none=True)
+        return self.model_dump(exclude_none=True, mode="json")
 
 
 class StatusDetails(BaseModel):
@@ -121,3 +128,202 @@ class QuickEditResult(BaseModel):
     export_links: list[str] | None = Field(None, description="URLs to download exported images")
     downloaded_files: list[str] | None = Field(None, description="Local paths of downloaded edited files")
     exported_files: list[str] | None = Field(None, description="Local paths of downloaded exported files")
+
+
+# =============================================================================
+# SKY REPLACEMENT TEMPLATES
+# =============================================================================
+
+
+class SkyTemplate(BaseModel):
+    id: int = Field(..., description="Sky replacement template ID")
+    is_default: bool = Field(..., description="Whether this is the default sky template")
+
+
+class SkyTemplatesResponse(BaseModel):
+    templates: list[SkyTemplate] = Field(..., description="Available sky replacement templates")
+
+
+# =============================================================================
+# PROJECT LISTING / RETRIEVAL
+# =============================================================================
+
+
+class PaginationInfo(BaseModel):
+    total: int = Field(..., description="Total number of matching projects")
+    size: int = Field(..., description="Page size")
+    page: int = Field(..., description="Current page index (0-based)")
+
+
+class ProjectListItem(BaseModel):
+    project_id: int | None = Field(None, description="Numeric project ID")
+    project_uuid: str = Field(..., description="Project UUID")
+    name: str | None = Field(None, description="Project name")
+    status: str = Field(..., description="Project status")
+    created_at: str = Field(..., description="Creation timestamp")
+    number_of_images: int = Field(..., description="Number of images in the project")
+    profile: str | None = Field(None, description="Profile associated with the project")
+    ai_tools: list[str] | None = Field(None, description="AI tools applied/available for the project")
+    customer_reference_id: int = Field(..., description="Customer reference ID")
+    thumbnail_src: str | None = Field(None, description="Thumbnail image URL")
+    export_status: str | None = Field(None, description="Export status, if any")
+
+
+class ProjectListResponse(BaseModel):
+    projects: list[ProjectListItem] = Field(..., description="Projects on this page")
+    pagination: PaginationInfo = Field(..., description="Pagination metadata")
+
+
+# =============================================================================
+# PER-IMAGE EXPORT LINKS
+# =============================================================================
+
+
+class TemporaryFileUploadData(BaseModel):
+    file_name: str = Field(..., description="Name of the file")
+    upload_link: str = Field(..., description="Presigned URL for upload")
+
+
+class FileDownloadInfo(BaseModel):
+    file_name: str = Field(..., description="Name of the file")
+    download_link: str = Field(..., description="URL to download the file")
+
+
+# =============================================================================
+# AI ENHANCEMENT / COPILOT / FINALIZE REQUESTS
+# =============================================================================
+
+
+class AITool(BaseModel):
+    """A single AI enhancement (quick) tool available for a project.
+
+    The ``enhancement_type`` value is what you pass as ``tool_id`` to ``enhance_image``.
+    Extra fields returned by the API are preserved.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    enhancement_type: str = Field(..., description="Tool identifier; use as enhance_image's tool_id")
+    label: str | None = Field(None, description="Human-readable tool name")
+    enabled_for_batch: bool | None = Field(None, description="Whether the tool can run across a batch")
+
+
+class AIToolsResponse(BaseModel):
+    """Response describing the AI enhancement tools available for a project."""
+
+    model_config = ConfigDict(extra="allow")
+
+    prompts: list[AITool] = Field(default_factory=list, description="Available AI enhancement tools")
+
+
+class EnhanceResult(BaseModel):
+    """Result of an AI enhancement (``enhance_image``) or copilot (``apply_copilot``) operation.
+
+    Mirrors the server's ``AIEnhancementResponse``. ``version_id`` is intentionally
+    untyped (``Any``) because the API declares it as an optional, open-typed field.
+    Unrecognized fields are preserved.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    status: str = Field(..., description="Operation status, e.g. 'SUCCESS'")
+    version_id: Any = Field(None, description="Version ID of the produced image, if any")
+    enhanced_image_url: str = Field(..., description="URL of the enhanced image")
+
+
+class EnhanceImageRequest(BaseModel):
+    tool_id: str = Field(..., min_length=1, description="Identifier of the AI quick tool to apply")
+    parent_version_id: int | None = Field(None, description="Version ID to base this enhancement on")
+    project_source: ProjectSource = Field(ProjectSource.REGULAR, description="Project source (REGULAR or I2I)")
+
+    def to_api_dict(self) -> dict[str, Any]:
+        return self.model_dump(exclude_none=True, mode="json")
+
+
+class CopilotRequest(BaseModel):
+    instruction: str = Field(..., min_length=1, max_length=255, description="Natural language editing instruction")
+    parent_version_id: int | None = Field(None, description="Version ID to base this instruction on")
+    project_source: ProjectSource = Field(ProjectSource.REGULAR, description="Project source (REGULAR or I2I)")
+
+    def to_api_dict(self) -> dict[str, Any]:
+        return self.model_dump(exclude_none=True, mode="json")
+
+
+class ResetCopilotRequest(BaseModel):
+    project_source: ProjectSource = Field(ProjectSource.REGULAR, description="Project source (REGULAR or I2I)")
+
+    def to_api_dict(self) -> dict[str, Any]:
+        return self.model_dump(mode="json")
+
+
+class FinalizeProjectRequest(BaseModel):
+    project_source: ProjectSource = Field(ProjectSource.REGULAR, description="Project source (REGULAR or I2I)")
+
+    def to_api_dict(self) -> dict[str, Any]:
+        return self.model_dump(mode="json")
+
+
+# =============================================================================
+# I2I (IMAGE-TO-IMAGE) EDIT + MULTIPART UPLOADS
+# =============================================================================
+
+
+class I2IEditOptions(BaseModel):
+    hdr_merge: bool | None = Field(None, description="Whether to apply HDR merge")
+    sky_replacement: bool | None = Field(None, description="Whether to apply sky replacement")
+    sky_replacement_template_id: int | None = Field(None, description="Sky replacement template ID")
+    perspective_correction: bool | None = Field(None, description="Whether to correct perspective")
+    callback_url: str | None = Field(None, description="Optional webhook URL called when editing completes")
+
+    def to_api_dict(self) -> dict[str, Any]:
+        return self.model_dump(exclude_none=True, mode="json")
+
+
+class CreateMultipartUploadLinksRequest(BaseModel):
+    file_name: str = Field(..., min_length=1, description="Name of the file to upload")
+    part_count: int = Field(..., ge=1, le=10000, description="Number of parts the file is split into")
+
+    def to_api_dict(self) -> dict[str, Any]:
+        return self.model_dump(mode="json")
+
+
+class MultipartUploadPartUrl(BaseModel):
+    part_number: int = Field(..., description="1-based part number")
+    upload_url: str = Field(..., description="Presigned URL for this part")
+
+
+class MultipartUploadLinksResponse(BaseModel):
+    upload_id: str = Field(..., description="Multipart upload ID")
+    key: str = Field(..., description="Storage key for the upload")
+    parts: list[MultipartUploadPartUrl] = Field(..., description="Presigned URLs for each part")
+
+
+class CompleteMultipartUploadRequest(BaseModel):
+    file_name: str = Field(..., min_length=1, description="Name of the uploaded file")
+
+    def to_api_dict(self) -> dict[str, Any]:
+        return self.model_dump(mode="json")
+
+
+class MessageResponse(BaseModel):
+    """A simple ``{"message": ...}`` response (e.g. from ``start_i2i_editing``)."""
+
+    model_config = ConfigDict(extra="allow")
+
+    message: str = Field(..., description="Human-readable status message")
+
+
+class SingleDownloadLink(BaseModel):
+    """A single download link, as returned by ``get_i2i_download_link``."""
+
+    model_config = ConfigDict(extra="allow")
+
+    download_link: str = Field(..., description="Temporary URL to download the file")
+
+
+class CreateFilesUploadLinksRequest(BaseModel):
+    files_list: list[FileUploadInfo] = Field(..., description="Files to obtain upload links for")
+    client_type: ClientType = Field(ClientType.API, description="Client type for the upload request")
+
+    def to_api_dict(self) -> dict[str, Any]:
+        return self.model_dump(exclude_none=True, mode="json")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "imagen-ai-sdk"
-version = "1.0.1"
+version = "1.1.0"
 description = "A robust, Pydantic-powered SDK for the Imagen AI photo editing workflow"
 authors = [{name = "Shahar Polak", email = "shahar@imagen-ai.com"}]
 license = {text = "MIT"}
@@ -90,6 +90,13 @@ exclude_lines = [
     "raise NotImplementedError",
     "if __name__ == .__main__.:",
 ]
+
+[tool.mypy]
+plugins = ["pydantic.mypy"]
+
+[[tool.mypy.overrides]]
+module = ["aiofiles", "aiofiles.*"]
+ignore_missing_imports = true
 
 [tool.ruff]
 target-version = "py310"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,33 @@
+"""Shared pytest fixtures for the Imagen SDK test suite."""
+
+from unittest.mock import patch
+
+import pytest
+
+from imagen_sdk import ImagenClient
+
+
+@pytest.fixture
+def api_key():
+    """Test API key."""
+    return "test-api-key"
+
+
+@pytest.fixture
+def client(api_key):
+    """An ImagenClient instance for tests."""
+    return ImagenClient(api_key)
+
+
+@pytest.fixture
+def mock_request_factory(client):
+    """Factory that patches client._make_request to return a fixed value.
+
+    `unittest.mock.patch` auto-detects the async method and substitutes an
+    AsyncMock, so the patched coroutine is awaitable.
+    """
+
+    def _create_mock_request(return_value):
+        return patch.object(client, "_make_request", return_value=return_value)
+
+    return _create_mock_request

--- a/tests/test_enhancement.py
+++ b/tests/test_enhancement.py
@@ -1,0 +1,121 @@
+"""Tests for the AI enhancement / copilot / finalize mixin."""
+
+import pytest
+from pydantic import ValidationError
+
+from imagen_sdk import ImagenError, ProjectSource
+
+
+class TestAITools:
+    @pytest.mark.asyncio
+    async def test_get_ai_tools_parsed(self, client, mock_request_factory):
+        response = {
+            "prompts": [
+                {"enhancement_type": "virtual_staging", "label": "Virtual staging", "enabled_for_batch": False},
+                {"enhancement_type": "remove_cameraman", "label": "Remove camera", "enabled_for_batch": True},
+            ]
+        }
+        with mock_request_factory(response):
+            tools = await client.get_ai_tools("proj")
+            assert [t.enhancement_type for t in tools.prompts] == ["virtual_staging", "remove_cameraman"]
+            assert tools.prompts[1].enabled_for_batch is True
+            args, kwargs = client._make_request.call_args
+            assert args == ("GET", "/projects/proj/ai-tools")
+            assert kwargs["params"] == {"project_source": "REGULAR"}
+
+    @pytest.mark.asyncio
+    async def test_get_ai_tools_envelope_wrapped(self, client, mock_request_factory):
+        with mock_request_factory({"data": {"prompts": [{"enhancement_type": "green_grass"}]}}):
+            tools = await client.get_ai_tools("proj")
+            assert tools.prompts[0].enhancement_type == "green_grass"
+
+
+ENHANCE_RESPONSE = {"status": "SUCCESS", "version_id": 3, "enhanced_image_url": "https://img/enhanced.jpg"}
+
+
+class TestEnhanceImage:
+    @pytest.mark.asyncio
+    async def test_enhance_image_payload(self, client, mock_request_factory):
+        with mock_request_factory(ENHANCE_RESPONSE):
+            result = await client.enhance_image("proj", "img.jpg", "denoise", parent_version_id=5)
+            assert result.status == "SUCCESS"
+            assert result.version_id == 3
+            assert result.enhanced_image_url == "https://img/enhanced.jpg"
+            args, kwargs = client._make_request.call_args
+            assert args == ("POST", "/projects/proj/images/img.jpg/enhance")
+            assert kwargs["json"] == {
+                "tool_id": "denoise",
+                "parent_version_id": 5,
+                "project_source": "REGULAR",
+            }
+
+    @pytest.mark.asyncio
+    async def test_enhance_image_omits_none_parent(self, client, mock_request_factory):
+        with mock_request_factory(ENHANCE_RESPONSE):
+            await client.enhance_image("proj", "img.jpg", "denoise")
+            _, kwargs = client._make_request.call_args
+            assert "parent_version_id" not in kwargs["json"]
+
+    @pytest.mark.asyncio
+    async def test_enhance_image_envelope_wrapped(self, client, mock_request_factory):
+        with mock_request_factory({"data": ENHANCE_RESPONSE}):
+            result = await client.enhance_image("proj", "img.jpg", "denoise")
+            assert result.enhanced_image_url == "https://img/enhanced.jpg"
+
+
+class TestCopilot:
+    @pytest.mark.asyncio
+    async def test_apply_copilot_payload(self, client, mock_request_factory):
+        with mock_request_factory(ENHANCE_RESPONSE):
+            result = await client.apply_copilot("proj", "img.jpg", "make it warmer", project_source=ProjectSource.I2I)
+            assert result.status == "SUCCESS"
+            args, kwargs = client._make_request.call_args
+            assert args == ("POST", "/projects/proj/images/img.jpg/copilot")
+            assert kwargs["json"]["instruction"] == "make it warmer"
+            assert kwargs["json"]["project_source"] == "I2I"
+
+    @pytest.mark.asyncio
+    async def test_reset_copilot_uses_delete(self, client, mock_request_factory):
+        with mock_request_factory({}):
+            result = await client.reset_copilot("proj", "img.jpg")
+            assert result is None
+            args, kwargs = client._make_request.call_args
+            assert args == ("DELETE", "/projects/proj/images/img.jpg/copilot")
+            assert kwargs["json"] == {"project_source": "REGULAR"}
+
+
+class TestEnhancementBreakFlows:
+    @pytest.mark.asyncio
+    async def test_enhance_image_rejects_empty_tool_id(self, client):
+        # Boundary validation: tool_id must be non-empty (no request is made).
+        with pytest.raises(ValidationError):
+            await client.enhance_image("proj", "img.jpg", tool_id="")
+
+    @pytest.mark.asyncio
+    async def test_apply_copilot_rejects_overlong_instruction(self, client):
+        # Boundary validation: instruction is capped at 255 characters.
+        with pytest.raises(ValidationError):
+            await client.apply_copilot("proj", "img.jpg", "x" * 256)
+
+    @pytest.mark.asyncio
+    async def test_enhance_image_propagates_api_error(self, client):
+        # E.g. enhancing a not-yet-exported project surfaces the API error.
+        from unittest.mock import AsyncMock, patch
+
+        err = ImagenError("API Error (400): Project has not been exported yet.")
+        with patch.object(client, "_make_request", new=AsyncMock(side_effect=err)):
+            with pytest.raises(ImagenError, match="Project has not been exported yet."):
+                await client.enhance_image("bad-uuid", "img.jpg", tool_id="remove_cameraman")
+
+
+class TestFinalize:
+    @pytest.mark.asyncio
+    async def test_finalize_project(self, client, mock_request_factory):
+        response = {"files_list": [{"file_name": "a.jpg", "download_link": "https://dl/a.jpg"}]}
+        with mock_request_factory(response):
+            result = await client.finalize_project("proj", project_source=ProjectSource.I2I)
+            assert [f.file_name for f in result.files_list] == ["a.jpg"]
+            assert result.files_list[0].download_link == "https://dl/a.jpg"
+            args, kwargs = client._make_request.call_args
+            assert args == ("POST", "/projects/proj/finalize")
+            assert kwargs["json"] == {"project_source": "I2I"}

--- a/tests/test_i2i.py
+++ b/tests/test_i2i.py
@@ -94,6 +94,48 @@ class TestI2IUpload:
                 args, _ = client._make_request.call_args
                 assert args == ("POST", "/i2i/projects/proj/get_temporary_upload_links")
 
+    @pytest.mark.asyncio
+    async def test_large_file_auto_routes_to_multipart(self, client, tmp_path, mock_request_factory):
+        big = tmp_path / "big.bin"
+        big.write_bytes(b"x" * 50)
+        # threshold below the file size -> must use multipart, never the batch endpoint
+        with mock_request_factory({"files_list": []}):
+            with patch.object(client, "upload_i2i_file_multipart", new=AsyncMock()) as mp:
+                summary = await client.upload_i2i_images("proj", [str(big)], multipart_threshold=10)
+                assert summary.successful == 1 and summary.total == 1
+                mp.assert_awaited_once()
+                client._make_request.assert_not_called()  # no batch single-PUT request
+
+    @pytest.mark.asyncio
+    async def test_mixed_sizes_split_between_paths(self, client, tmp_path, mock_request_factory):
+        small = tmp_path / "small.jpg"
+        small.write_bytes(b"x" * 5)
+        big = tmp_path / "big.bin"
+        big.write_bytes(b"x" * 100)
+        response = {"files_list": [{"file_name": "small.jpg", "upload_link": "https://up"}]}
+        with mock_request_factory(response):
+            with (
+                patch.object(client, "_upload_to_s3", new=AsyncMock()) as put,
+                patch.object(client, "upload_i2i_file_multipart", new=AsyncMock()) as mp,
+            ):
+                summary = await client.upload_i2i_images("proj", [str(small), str(big)], multipart_threshold=10)
+                assert summary.total == 2 and summary.successful == 2
+                put.assert_awaited_once()  # small via single PUT
+                mp.assert_awaited_once()  # big via multipart
+                # batch request sent only the small file
+                _, kwargs = client._make_request.call_args
+                assert [f["file_name"] for f in kwargs["json"]["files_list"]] == ["small.jpg"]
+
+    @pytest.mark.asyncio
+    async def test_large_file_multipart_failure_recorded(self, client, tmp_path, mock_request_factory):
+        big = tmp_path / "big.bin"
+        big.write_bytes(b"x" * 50)
+        with mock_request_factory({"files_list": []}):
+            with patch.object(client, "upload_i2i_file_multipart", new=AsyncMock(side_effect=Exception("boom"))):
+                summary = await client.upload_i2i_images("proj", [str(big)], multipart_threshold=10)
+                assert summary.failed == 1 and summary.successful == 0
+                assert "boom" in summary.results[0].error
+
 
 class TestI2IMultipart:
     @pytest.mark.asyncio

--- a/tests/test_i2i.py
+++ b/tests/test_i2i.py
@@ -1,0 +1,206 @@
+"""Tests for the image-to-image (I2I) mixin, including multipart uploads."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic import ValidationError
+
+from imagen_sdk import I2IEditOptions, MultipartUploadLinksResponse, ProjectError, UploadError
+
+
+class TestI2IProjectLifecycle:
+    @pytest.mark.asyncio
+    async def test_create_i2i_project(self, client, mock_request_factory):
+        with mock_request_factory({"project_uuid": "i2i-1"}):
+            uuid = await client.create_i2i_project("My I2I")
+            assert uuid == "i2i-1"
+            client._make_request.assert_called_once_with("POST", "/i2i/projects/", json={"name": "My I2I"})
+
+    @pytest.mark.asyncio
+    async def test_create_i2i_project_wrapped(self, client, mock_request_factory):
+        with mock_request_factory({"data": {"project_uuid": "i2i-2"}}):
+            assert await client.create_i2i_project() == "i2i-2"
+
+    @pytest.mark.asyncio
+    async def test_list_i2i_projects(self, client, mock_request_factory):
+        response = {"projects": [], "pagination": {"total": 0, "size": 20, "page": 0}}
+        with mock_request_factory(response):
+            result = await client.list_i2i_projects()
+            assert result.pagination.total == 0
+            args, _ = client._make_request.call_args
+            assert args == ("GET", "/i2i/projects")
+
+    @pytest.mark.asyncio
+    async def test_validate_name_true(self, client, mock_request_factory):
+        with mock_request_factory({"is_valid": True}):
+            assert await client.validate_i2i_project_name("ok") is True
+
+    @pytest.mark.asyncio
+    async def test_validate_name_false(self, client, mock_request_factory):
+        with mock_request_factory({"is_valid": False}):
+            assert await client.validate_i2i_project_name("taken") is False
+
+    @pytest.mark.asyncio
+    async def test_validate_name_empty_response_means_valid(self, client, mock_request_factory):
+        with mock_request_factory({}):
+            assert await client.validate_i2i_project_name("ok") is True
+
+
+class TestI2IEditingAndDownloads:
+    @pytest.mark.asyncio
+    async def test_start_i2i_editing_with_options(self, client, mock_request_factory):
+        with mock_request_factory({"message": "Project proj sent for I2I editing successfully."}):
+            result = await client.start_i2i_editing("proj", I2IEditOptions(hdr_merge=True, perspective_correction=True))
+            assert result.message == "Project proj sent for I2I editing successfully."
+            args, kwargs = client._make_request.call_args
+            assert args == ("POST", "/i2i/projects/proj/edit")
+            assert kwargs["json"] == {"hdr_merge": True, "perspective_correction": True}
+
+    @pytest.mark.asyncio
+    async def test_start_i2i_editing_no_options(self, client, mock_request_factory):
+        with mock_request_factory({"message": "ok"}):
+            await client.start_i2i_editing("proj")
+            _, kwargs = client._make_request.call_args
+            assert kwargs["json"] == {}
+
+    @pytest.mark.asyncio
+    async def test_get_i2i_download_links(self, client, mock_request_factory):
+        response = {"files_list": [{"file_name": "a.jpg", "download_link": "https://dl1"}]}
+        with mock_request_factory(response):
+            links = await client.get_i2i_download_links("proj")
+            assert links == ["https://dl1"]
+
+    @pytest.mark.asyncio
+    async def test_get_i2i_download_link(self, client, mock_request_factory):
+        with mock_request_factory({"download_link": "https://dl/single.jpg"}):
+            result = await client.get_i2i_download_link("proj", "single.jpg")
+            assert result.download_link == "https://dl/single.jpg"
+            args, kwargs = client._make_request.call_args
+            assert args == ("GET", "/i2i/projects/proj/get_download_link")
+            assert kwargs["params"] == {"file_name": "single.jpg"}
+
+
+class TestI2IUpload:
+    @pytest.mark.asyncio
+    async def test_upload_i2i_images(self, client, tmp_path, mock_request_factory):
+        f1 = tmp_path / "img1.jpg"
+        f1.write_bytes(b"data")
+        response = {"files_list": [{"file_name": "img1.jpg", "upload_link": "https://up1"}]}
+        with mock_request_factory(response):
+            with patch.object(client, "_upload_to_s3", new=AsyncMock()) as mock_put:
+                summary = await client.upload_i2i_images("proj", [str(f1)])
+                assert summary.successful == 1
+                mock_put.assert_awaited_once()
+                args, _ = client._make_request.call_args
+                assert args == ("POST", "/i2i/projects/proj/get_temporary_upload_links")
+
+
+class TestI2IMultipart:
+    @pytest.mark.asyncio
+    async def test_create_multipart_payload(self, client, mock_request_factory):
+        response = {"upload_id": "uid", "key": "k", "parts": [{"part_number": 1, "upload_url": "https://u1"}]}
+        with mock_request_factory(response):
+            result = await client.create_i2i_multipart_upload("proj", "big.arw", 1)
+            assert result.upload_id == "uid"
+            args, kwargs = client._make_request.call_args
+            assert args == ("POST", "/i2i/projects/proj/multipart_uploads")
+            assert kwargs["json"] == {"file_name": "big.arw", "part_count": 1}
+
+    @pytest.mark.asyncio
+    async def test_complete_multipart_payload(self, client, mock_request_factory):
+        with mock_request_factory({}):
+            await client.complete_i2i_multipart_upload("proj", "uid", "big.arw")
+            args, kwargs = client._make_request.call_args
+            assert args == ("POST", "/i2i/projects/proj/multipart_uploads/uid/complete")
+            assert kwargs["json"] == {"file_name": "big.arw"}
+
+    @pytest.mark.asyncio
+    async def test_abort_multipart_payload(self, client, mock_request_factory):
+        with mock_request_factory({}):
+            await client.abort_i2i_multipart_upload("proj", "uid", "k")
+            args, kwargs = client._make_request.call_args
+            assert args == ("DELETE", "/i2i/projects/proj/multipart_uploads/uid")
+            assert kwargs["json"] == {"key": "k"}
+
+    @pytest.mark.asyncio
+    async def test_upload_file_multipart_success(self, client, tmp_path):
+        big = tmp_path / "big.bin"
+        big.write_bytes(b"0123456789" * 3)  # 30 bytes
+
+        links = MultipartUploadLinksResponse(
+            upload_id="uid",
+            key="k",
+            parts=[
+                {"part_number": 1, "upload_url": "https://u1"},
+                {"part_number": 2, "upload_url": "https://u2"},
+                {"part_number": 3, "upload_url": "https://u3"},
+            ],
+        )
+
+        # Mock the S3 PUT for each part.
+        put_response = MagicMock()
+        put_response.raise_for_status = MagicMock()
+        mock_http = AsyncMock()
+        mock_http.__aenter__ = AsyncMock(return_value=mock_http)
+        mock_http.__aexit__ = AsyncMock(return_value=None)
+        mock_http.put = AsyncMock(return_value=put_response)
+
+        with (
+            patch.object(client, "create_i2i_multipart_upload", new=AsyncMock(return_value=links)),
+            patch.object(client, "complete_i2i_multipart_upload", new=AsyncMock()) as mock_complete,
+            patch("imagen_sdk._i2i.httpx.AsyncClient", return_value=mock_http),
+        ):
+            result = await client.upload_i2i_file_multipart("proj", str(big), part_size=10)
+            assert result.upload_id == "uid"
+            assert mock_http.put.await_count == 3
+            mock_complete.assert_awaited_once_with("proj", "uid", "big.bin")
+
+    @pytest.mark.asyncio
+    async def test_create_multipart_rejects_too_many_parts(self, client):
+        # S3 caps multipart uploads at 10000 parts; the request model enforces it.
+        with pytest.raises(ValidationError):
+            await client.create_i2i_multipart_upload("proj", "big.arw", 10001)
+
+    @pytest.mark.asyncio
+    async def test_upload_file_multipart_rejects_invalid_concurrency(self, client, tmp_path):
+        f = tmp_path / "f.bin"
+        f.write_bytes(b"data")
+        with pytest.raises(ValueError, match="max_concurrent"):
+            await client.upload_i2i_file_multipart("proj", str(f), max_concurrent=0)
+
+    @pytest.mark.asyncio
+    async def test_upload_file_multipart_missing_file(self, client):
+        with pytest.raises(UploadError):
+            await client.upload_i2i_file_multipart("proj", "/nonexistent/file.bin")
+
+    @pytest.mark.asyncio
+    async def test_upload_file_multipart_aborts_on_failure(self, client, tmp_path):
+        big = tmp_path / "big.bin"
+        big.write_bytes(b"0123456789" * 2)
+
+        links = MultipartUploadLinksResponse(
+            upload_id="uid",
+            key="k",
+            parts=[{"part_number": 1, "upload_url": "https://u1"}],
+        )
+        mock_http = AsyncMock()
+        mock_http.__aenter__ = AsyncMock(return_value=mock_http)
+        mock_http.__aexit__ = AsyncMock(return_value=None)
+        mock_http.put = AsyncMock(side_effect=Exception("network down"))
+
+        with (
+            patch.object(client, "create_i2i_multipart_upload", new=AsyncMock(return_value=links)),
+            patch.object(client, "abort_i2i_multipart_upload", new=AsyncMock()) as mock_abort,
+            patch("imagen_sdk._i2i.httpx.AsyncClient", return_value=mock_http),
+        ):
+            with pytest.raises(UploadError):
+                await client.upload_i2i_file_multipart("proj", str(big), part_size=10)
+            mock_abort.assert_awaited_once_with("proj", "uid", "k")
+
+
+class TestI2IGetProject:
+    @pytest.mark.asyncio
+    async def test_get_i2i_project_invalid(self, client, mock_request_factory):
+        with mock_request_factory({"bad": 1}):
+            with pytest.raises(ProjectError):
+                await client.get_i2i_project("uuid")

--- a/tests/test_imagen_client.py
+++ b/tests/test_imagen_client.py
@@ -106,7 +106,7 @@ class TestImagenClientInit:
     def test_default_initialization(self, api_key):
         client = ImagenClient(api_key)
         assert client.api_key == api_key
-        assert client.base_url == "https://api-beta.imagen-ai.com/v1"
+        assert client.base_url == "https://api.imagen-ai.com/v1"
         assert client._session is None
 
     def test_custom_base_url(self, api_key):
@@ -171,7 +171,7 @@ class TestImagenClientRequests:
             result = await client._make_request("GET", "/test")
 
             assert result == json_data
-            mock_session.return_value.request.assert_called_once_with("GET", "https://api-beta.imagen-ai.com/v1/test")
+            mock_session.return_value.request.assert_called_once_with("GET", "https://api.imagen-ai.com/v1/test")
 
     @pytest.mark.asyncio
     async def test_make_request_success_204(self, client, mock_helpers):
@@ -194,7 +194,7 @@ class TestImagenClientRequests:
             await client._make_request("GET", "///test///")
 
             # Should normalize the URL
-            expected_url = "https://api-beta.imagen-ai.com/v1/test///"
+            expected_url = "https://api.imagen-ai.com/v1/test///"
             mock_session.return_value.request.assert_called_once_with("GET", expected_url)
 
     @pytest.mark.asyncio
@@ -216,6 +216,18 @@ class TestImagenClientRequests:
             mock_session.return_value.request = AsyncMock(return_value=mock_response)
 
             with pytest.raises(ImagenError, match="API Error \\(400\\): Bad request details"):
+                await client._make_request("GET", "/test")
+
+    @pytest.mark.asyncio
+    async def test_make_request_400_with_error_envelope(self, client, mock_helpers):
+        # Production error shape: {"error": {"message": ...}}
+        json_data = {"error": {"message": "Only realistic editing requests are supported"}}
+        mock_response = mock_helpers.create_http_response(400, json_data, '{"error": {"message": "..."}}')
+
+        with patch.object(client, "_get_session") as mock_session:
+            mock_session.return_value.request = AsyncMock(return_value=mock_response)
+
+            with pytest.raises(ImagenError, match="API Error \\(400\\): Only realistic editing requests are supported"):
                 await client._make_request("GET", "/test")
 
     @pytest.mark.asyncio

--- a/tests/test_imagen_workflow.py
+++ b/tests/test_imagen_workflow.py
@@ -134,7 +134,7 @@ class TestConvenienceFunctions:
             assert profiles[2].profile_type == "Talent"
 
             # Verify client was created and used correctly
-            mock_client_class.assert_called_once_with("test-api-key", "https://api-beta.imagen-ai.com/v1")
+            mock_client_class.assert_called_once_with("test-api-key", "https://api.imagen-ai.com/v1")
             mock_client.get_profiles.assert_called_once()
 
     @pytest.mark.asyncio

--- a/tests/test_models_and_unwrap.py
+++ b/tests/test_models_and_unwrap.py
@@ -1,0 +1,100 @@
+"""Tests for new enums, EditOptions fields, request models, and the _unwrap helper."""
+
+import pytest
+
+from imagen_sdk import (
+    ClientType,
+    CopilotRequest,
+    DNGCompression,
+    EditOptions,
+    EnhanceImageRequest,
+    I2IEditOptions,
+    ImagenClient,
+    PhotographyType,
+    ProjectSource,
+)
+
+
+class TestUnwrap:
+    """Envelope-tolerant _unwrap behavior."""
+
+    def test_unwraps_sole_data_key(self):
+        assert ImagenClient._unwrap({"data": {"project_uuid": "x"}}) == {"project_uuid": "x"}
+
+    def test_passes_through_unwrapped_dict(self):
+        payload = {"project_uuid": "x"}
+        assert ImagenClient._unwrap(payload) == payload
+
+    def test_does_not_unwrap_when_data_not_sole_key(self):
+        payload = {"data": 1, "other": 2}
+        assert ImagenClient._unwrap(payload) == payload
+
+    def test_passes_through_list(self):
+        payload = [{"a": 1}]
+        assert ImagenClient._unwrap(payload) == payload
+
+    def test_passes_through_scalar(self):
+        assert ImagenClient._unwrap("uuid-str") == "uuid-str"
+
+
+class TestEnumAdditions:
+    def test_photography_type_school(self):
+        assert PhotographyType.SCHOOL.value == "SCHOOL"
+
+    def test_dng_compression_values(self):
+        assert {c.value for c in DNGCompression} == {"LOSSY", "LOSSLESS"}
+
+    def test_project_source_values(self):
+        assert {s.value for s in ProjectSource} == {"REGULAR", "I2I"}
+
+    def test_client_type_values(self):
+        assert {c.value for c in ClientType} == {"APP", "API", "MOBILE", "WEB_REAL_ESTATE"}
+
+
+class TestEditOptionsNewFields:
+    def test_hdr_output_compression_serializes_to_value(self):
+        opts = EditOptions(hdr_merge=True, hdr_output_compression=DNGCompression.LOSSLESS)
+        api = opts.to_api_dict()
+        assert api["hdr_output_compression"] == "LOSSLESS"
+        assert api["hdr_merge"] is True
+
+    def test_callback_url_included(self):
+        opts = EditOptions(callback_url="https://example.com/hook")
+        assert opts.to_api_dict()["callback_url"] == "https://example.com/hook"
+
+    def test_none_fields_excluded(self):
+        opts = EditOptions(crop=True)
+        api = opts.to_api_dict()
+        assert "callback_url" not in api
+        assert "hdr_output_compression" not in api
+
+    def test_existing_mutual_exclusivity_still_enforced(self):
+        with pytest.raises(ValueError):
+            EditOptions(crop=True, headshot_crop=True)
+
+
+class TestRequestModels:
+    def test_enhance_request_excludes_none_parent(self):
+        req = EnhanceImageRequest(tool_id="denoise")
+        api = req.to_api_dict()
+        assert api == {"tool_id": "denoise", "project_source": "REGULAR"}
+
+    def test_copilot_request_validation_rejects_empty(self):
+        with pytest.raises(ValueError):
+            CopilotRequest(instruction="")
+
+    def test_copilot_request_rejects_too_long(self):
+        with pytest.raises(ValueError):
+            CopilotRequest(instruction="x" * 256)
+
+    def test_copilot_request_payload(self):
+        req = CopilotRequest(instruction="brighten the sky", parent_version_id=3, project_source=ProjectSource.I2I)
+        assert req.to_api_dict() == {
+            "instruction": "brighten the sky",
+            "parent_version_id": 3,
+            "project_source": "I2I",
+        }
+
+    def test_i2i_edit_options_excludes_none(self):
+        opts = I2IEditOptions(hdr_merge=True, callback_url="https://cb")
+        assert opts.to_api_dict() == {"hdr_merge": True, "callback_url": "https://cb"}

--- a/tests/test_projects_mgmt.py
+++ b/tests/test_projects_mgmt.py
@@ -1,0 +1,108 @@
+"""Tests for the project management mixin (listing, retrieval, sky templates, export links)."""
+
+import pytest
+
+from imagen_sdk import ImagenError, ProjectError
+
+
+def _project_item(uuid="p-1", name="My Project"):
+    return {
+        "project_id": 1,
+        "project_uuid": uuid,
+        "name": name,
+        "status": "Completed",
+        "created_at": "2026-01-01T00:00:00Z",
+        "number_of_images": 3,
+        "profile": "Wedding",
+        "ai_tools": ["denoise"],
+        "customer_reference_id": 42,
+        "thumbnail_src": None,
+        "export_status": None,
+    }
+
+
+class TestListProjects:
+    @pytest.mark.asyncio
+    async def test_list_projects_unwrapped(self, client, mock_request_factory):
+        response = {"projects": [_project_item()], "pagination": {"total": 1, "size": 20, "page": 0}}
+        with mock_request_factory(response):
+            result = await client.list_projects()
+            assert result.pagination.total == 1
+            assert result.projects[0].project_uuid == "p-1"
+            client._make_request.assert_called_once()
+            args, kwargs = client._make_request.call_args
+            assert args[0] == "GET"
+            assert args[1] == "/projects"
+            assert kwargs["params"]["client_type"] == "API"
+
+    @pytest.mark.asyncio
+    async def test_list_projects_wrapped_envelope(self, client, mock_request_factory):
+        response = {"data": {"projects": [_project_item()], "pagination": {"total": 1, "size": 20, "page": 0}}}
+        with mock_request_factory(response):
+            result = await client.list_projects()
+            assert result.projects[0].name == "My Project"
+
+    @pytest.mark.asyncio
+    async def test_list_projects_invalid(self, client, mock_request_factory):
+        with mock_request_factory({"unexpected": True}):
+            with pytest.raises(ProjectError):
+                await client.list_projects()
+
+
+class TestGetProject:
+    @pytest.mark.asyncio
+    async def test_get_project(self, client, mock_request_factory):
+        with mock_request_factory(_project_item(uuid="abc")):
+            item = await client.get_project("abc")
+            assert item.project_uuid == "abc"
+            assert item.number_of_images == 3
+
+
+class TestGetProjectUuid:
+    @pytest.mark.asyncio
+    async def test_dict_with_project_uuid(self, client, mock_request_factory):
+        with mock_request_factory({"project_uuid": "u-123"}):
+            assert await client.get_project_uuid("name") == "u-123"
+
+    @pytest.mark.asyncio
+    async def test_bare_string(self, client, mock_request_factory):
+        with mock_request_factory("u-456"):
+            assert await client.get_project_uuid("name") == "u-456"
+
+    @pytest.mark.asyncio
+    async def test_unresolvable_raises(self, client, mock_request_factory):
+        with mock_request_factory({"nope": 1}):
+            with pytest.raises(ProjectError):
+                await client.get_project_uuid("name")
+
+
+class TestSkyTemplates:
+    @pytest.mark.asyncio
+    async def test_get_sky_templates(self, client, mock_request_factory):
+        response = {"templates": [{"id": 1, "is_default": True}, {"id": 2, "is_default": False}]}
+        with mock_request_factory(response):
+            templates = await client.get_sky_replacement_templates()
+            assert [t.id for t in templates] == [1, 2]
+            assert templates[0].is_default is True
+
+    @pytest.mark.asyncio
+    async def test_get_sky_templates_invalid(self, client, mock_request_factory):
+        with mock_request_factory({"bad": 1}):
+            with pytest.raises(ImagenError):
+                await client.get_sky_replacement_templates()
+
+
+class TestExportLinks:
+    @pytest.mark.asyncio
+    async def test_export_upload_link(self, client, mock_request_factory):
+        with mock_request_factory({"file_name": "a.jpg", "upload_link": "https://up"}):
+            data = await client.get_export_upload_link("p", "a.jpg")
+            assert data.upload_link == "https://up"
+            args, kwargs = client._make_request.call_args
+            assert kwargs["params"] == {"file_name": "a.jpg"}
+
+    @pytest.mark.asyncio
+    async def test_export_download_link(self, client, mock_request_factory):
+        with mock_request_factory({"file_name": "a.jpg", "download_link": "https://dl"}):
+            data = await client.get_export_download_link("p", "a.jpg")
+            assert data.download_link == "https://dl"


### PR DESCRIPTION
## Summary

Expands `imagen-ai-sdk` to **v1.1.0** with new API surface beyond the classic create -> upload -> edit -> download -> export flow. Every new response shape was **verified against the `api-gateway` source** before typing.

**Fully backward compatible** — no existing method signature, model, or export changed. The default `base_url` now targets production (`https://api.imagen-ai.com/v1`); beta is retired.

## What's new

- **Project management** (`_projects.py`): `list_projects`, `get_project`, `get_project_uuid`, `get_sky_replacement_templates`, per-image export upload/download links.
- **AI enhancement / copilot** (`_enhancement.py`): `get_ai_tools`, `enhance_image`, `apply_copilot`, `reset_copilot`, `finalize_project`. `enhance_image`/`apply_copilot` return the typed `EnhanceResult`; `finalize_project` returns `DownloadLinksList`.
- **Image-to-image (I2I)** (`_i2i.py`): full `/v1/i2i/...` family including S3 **multipart upload** for large files (bounded memory, abort-on-failure), `start_i2i_editing` (`MessageResponse`), `get_i2i_download_link` (`SingleDownloadLink`).
- **I2I upload auto-routing**: `upload_i2i_images` is now the single recommended entry point — each file is routed by size (`<= multipart_threshold` -> batched single PUT; above -> multipart) so callers never choose a mechanism. Results from both paths merge into one `UploadSummary` (partial-success preserved). Multipart part size auto-grows to stay within S3's 10,000-part cap. `upload_i2i_file_multipart` remains as an advanced escape hatch.

## Notable fixes & internals

- **Error parsing fix**: `_make_request` now prefers `error.message`, falls back to `detail`, then raw text — matching the production `{\"error\": {\"message\": ...}}` envelope (previously surfaced raw JSON).
- Envelope-tolerant `_unwrap` + shared `_parse_model` helper across all parse sites.
- Removed dead `AbortMultipartUploadRequest`.
- Enabled the pydantic mypy plugin.

## Verified behavior (documented)

- The enhancement pipeline requires an **exported** project (`400 \"Project has not been exported yet.\"`).
- **Realistic-only** gating is enforced downstream, surfaced as `ImagenError`.
- I2I has **no status endpoint** — poll downloads or use `callback_url`.

Documented in method docstrings, README, and `docs/WORKFLOWS.md` (language-neutral behavioral contract; §7 updated to describe upload auto-routing).

## Test plan

- [x] `ruff check`, `ruff format --check`, `mypy` — all clean
- [x] **185 tests pass** (added I2I upload auto-route, mixed-size split, and multipart-failure tests on top of typed-response, error-envelope, and break-flow coverage)
- [ ] Reviewer: confirm production `base_url` default is desired for this release