### PR TITLE
chore(node): point package metadata at monorepo; bump 1.1.1

### DIFF
--- a/sdks/node/package.json
+++ b/sdks/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "imagen-ai-sdk",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Node.js/TypeScript SDK for the Imagen AI photo editing workflow",
   "author": "Shahar Polak <shahar@imagen-ai.com>",
   "license": "MIT",
@@ -15,7 +15,12 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/imagenai/imagen-ai-node-sdk"
+    "url": "git+https://github.com/imagenai/imagen-ai-sdk.git",
+    "directory": "sdks/node"
+  },
+  "homepage": "https://github.com/imagenai/imagen-ai-sdk/tree/master/sdks/node",
+  "bugs": {
+    "url": "https://github.com/imagenai/imagen-ai-sdk/issues"
   },
   "engines": {
     "node": ">=18.0.0"


### PR DESCRIPTION
Updates the Node SDK `package.json` to reflect the monorepo layout.

## Changes
- `repository.url` → `imagenai/imagen-ai-sdk` (old `imagen-ai-node-sdk` repo is being deleted)
- Added `repository.directory: sdks/node` so npm links to the subdir
- Added `homepage` and `bugs` links
- Bumped version to `1.1.1` to match what's published on npm

## Notes
`1.1.1` is already live on npm with this metadata; this commits the source of truth.