### PR TITLE
feat(cli): agent-native `imagen` CLI + enriched skill

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -53,7 +53,8 @@ jobs:
           python-version: "3.11"
       - run: pip install -e . pyinstaller
       - name: Build binary
-        run: pyinstaller --onefile --name imagen --clean --noconfirm --paths . --collect-submodules imagen_sdk packaging/imagen_entry.py
+        shell: bash
+        run: sh packaging/build.sh
       - name: Rename to asset name
         shell: bash
         run: |

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -1,0 +1,82 @@
+name: Release CLI
+
+# Builds the standalone `imagen` binary (no Python needed by end users) for each
+# platform and attaches them to a GitHub release. Asset names match what
+# sdks/python/packaging/install.sh downloads.
+#
+# Gated on a deliberate `cli-v*` tag so merging to master never publishes.
+# Tests must pass before any binary is built.
+
+on:
+  push:
+    tags:
+      - "cli-v*"
+  workflow_dispatch:
+
+defaults:
+  run:
+    working-directory: sdks/python
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: pip install -e ".[dev]"
+      - run: python -m ruff check imagen_sdk/
+      - run: python -m pytest tests/ -q
+
+  build:
+    needs: test
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: macos-14      # Apple Silicon
+            asset: imagen-macos-arm64
+          - runner: macos-13      # Intel
+            asset: imagen-macos-x64
+          - runner: ubuntu-latest
+            asset: imagen-linux-x64
+          - runner: ubuntu-24.04-arm
+            asset: imagen-linux-arm64
+          - runner: windows-latest
+            asset: imagen-windows-x64.exe
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: pip install -e . pyinstaller
+      - name: Build binary
+        run: pyinstaller --onefile --name imagen --clean --noconfirm --paths . --collect-submodules imagen_sdk packaging/imagen_entry.py
+      - name: Rename to asset name
+        shell: bash
+        run: |
+          if [ "${{ runner.os }}" = "Windows" ]; then
+            mv dist/imagen.exe "dist/${{ matrix.asset }}"
+          else
+            mv dist/imagen "dist/${{ matrix.asset }}"
+          fi
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.asset }}
+          path: sdks/python/dist/${{ matrix.asset }}
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+      - uses: softprops/action-gh-release@v2
+        with:
+          files: artifacts/*

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -69,6 +69,9 @@ jobs:
 
   release:
     needs: build
+    # Only publish a release for an actual cli-v* tag. A manual workflow_dispatch
+    # run still builds the binaries (for testing) but does not create a release.
+    if: startsWith(github.ref, 'refs/tags/cli-v')
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,9 @@ MANIFEST
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.
 *.manifest
 *.spec
+# Generated docs scratch (curated docs like WORKFLOWS.md / CLI.md stay tracked)
+docs/plans/
+docs/reports/
 # Installer logs
 pip-log.txt
 pip-delete-this-directory.txt

--- a/.gitignore
+++ b/.gitignore
@@ -34,7 +34,6 @@ MANIFEST
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.
 *.manifest
 *.spec
-docs
 # Installer logs
 pip-log.txt
 pip-delete-this-directory.txt

--- a/README.md
+++ b/README.md
@@ -10,6 +10,17 @@ Multi-language SDK monorepo for the [Imagen AI](https://imagen-ai.com) photo-edi
 
 See each SDK's own README for full usage and examples.
 
+## Command-line tool
+
+Prefer the terminal (or driving Imagen from an AI agent)? The **`imagen` CLI** is
+a single self-contained binary — no Python required — that wraps the full API
+with `--json` output and stable exit codes. See [`docs/CLI.md`](docs/CLI.md).
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/imagenai/imagen-ai-sdk/master/sdks/python/packaging/install.sh | sh
+imagen edit ./raws --profile 328 --type wedding --crop
+```
+
 ## Repository layout
 
 ```

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -26,7 +26,19 @@ imagen --version
 ```
 
 > **Developing from source?** `pip install -e sdks/python` also installs the
-> `imagen` command (this is what the test suite uses).
+> `imagen` command tracking your live source (no rebuild needed) — this is what
+> the test suite uses.
+>
+> **Rebuilding the standalone binary?** The binary is compiled from the SDK
+> source, so it only reflects changes after a rebuild. Run the single build
+> script (same one CI uses, so local and released binaries match):
+>
+> ```bash
+> pip install pyinstaller
+> sh sdks/python/packaging/build.sh   # -> sdks/python/dist/imagen
+> ```
+>
+> Released binaries are rebuilt automatically by CI on every `cli-v*` tag.
 
 ---
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1,0 +1,152 @@
+# `imagen` CLI
+
+A standalone command-line tool for the Imagen AI photo-editing API. It wraps the
+full API surface and is built to be driven by **both humans and AI agents**:
+every command supports `--json`, uses stable exit codes, and never prompts
+interactively.
+
+**No Python required** — the CLI ships as a single self-contained binary.
+
+---
+
+## Install
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/imagenai/imagen-ai-sdk/master/sdks/python/packaging/install.sh | sh
+```
+
+The installer downloads the right binary for your platform (macOS arm64/x64,
+Linux x64/arm64) into `~/.local/bin`. On Windows, download `imagen-windows-x64.exe`
+from the [latest release](https://github.com/imagenai/imagen-ai-sdk/releases/latest).
+
+Verify:
+
+```bash
+imagen --version
+```
+
+> **Developing from source?** `pip install -e sdks/python` also installs the
+> `imagen` command (this is what the test suite uses).
+
+---
+
+## Authentication
+
+The CLI looks for your API key in this order:
+
+1. `--api-key <key>` flag
+2. `IMAGEN_API_KEY` environment variable
+3. `~/.imagen/config.json` (written by `imagen config`)
+
+Set it once and forget it:
+
+```bash
+imagen config --api-key <YOUR_KEY>
+imagen config --profile 328        # optional default editing profile
+imagen config                      # show current config (key is masked)
+```
+
+---
+
+## Commands
+
+Run `imagen --help` or `imagen <command> --help` at any time — the CLI is
+self-documenting.
+
+| Command | What it does |
+|---------|--------------|
+| `imagen profiles` | List your editing profiles (each has a `profile_key`) |
+| `imagen projects` | List projects in your account (`--size`, `--page`) |
+| `imagen edit FOLDER --profile K` | Full workflow: create project → upload → edit → download |
+| `imagen enhance PROJECT FILE --tool-id T` | Apply an AI quick tool to an already-edited image |
+| `imagen i2i FOLDER` | Run the image-to-image editing workflow |
+| `imagen sky-templates` | List sky-replacement template ids |
+| `imagen ai-tools PROJECT` | List AI quick tools available for a project |
+| `imagen config` | Show or set persisted defaults |
+
+### Global options
+
+| Option | Meaning |
+|--------|---------|
+| `--json` | Emit a single machine-readable JSON document on stdout |
+| `--api-key TEXT` | Override the API key for this invocation |
+| `--base-url TEXT` | Override the API base URL |
+| `-V, --version` | Print the version |
+
+Global options go **before** the command: `imagen --json profiles`.
+
+---
+
+## Editing photos
+
+```bash
+# 1. Find a profile key
+imagen profiles
+
+# 2. Edit a folder of RAW files with profile 328, as a wedding, with crop + skin smoothing
+imagen edit ./raws --profile 328 --type wedding --crop --smooth-skin --out ./edited
+
+# Also export final JPEGs
+imagen edit ./raws --profile 328 --export
+```
+
+`edit` accepts a folder or a single file. Results download by default
+(`--no-download` to skip). Editing options map 1:1 to the API:
+
+`--crop` · `--straighten` · `--hdr-merge` · `--portrait-crop` · `--smooth-skin`
+· `--subject-mask` · `--headshot-crop` · `--perspective-correction`
+· `--sky-replacement` · `--sky-template-id N` · `--window-pull`
+· `--crop-aspect-ratio 2X3|4X5|5X7`
+
+Only pass the flags you want enabled; unset flags are left untouched.
+
+### Photography types (`--type`)
+
+`no_type`, `other`, `portraits`, `wedding`, `real_estate`, `landscape_nature`,
+`events`, `family_newborn`, `boudoir`, `sports`, `school` (case-insensitive).
+Passing the right type improves AI quality.
+
+### File-type rules
+
+- **RAW and JPEG cannot be mixed in one project.** If a folder contains both,
+  `edit` fails — run RAW-only and JPEG-only folders separately, each with a
+  matching profile (RAW profiles can't process JPEGs and vice versa).
+- Only the **top level** of the folder is scanned; subfolders (e.g. a previous
+  `edited/` output) are ignored.
+- Supported RAW: `.dng .nef .cr2 .arw .nrw .crw .orf .raw .rw2 .raf .ptx .pef .rwl .srw .cr3 .3fr .fff`
+- Supported JPEG: `.jpg .jpeg`. Other formats (HEIC, etc.) are skipped.
+
+---
+
+## JSON output and exit codes (for scripts and agents)
+
+Add `--json` to get a single JSON document on stdout. On failure, the CLI prints
+`{"error": "...", "message": "..."}` on **stderr** and returns a non-zero exit code:
+
+| Exit code | Meaning |
+|-----------|---------|
+| `0` | Success |
+| `2` | Authentication / configuration problem (missing or invalid key, missing profile) |
+| `1` | Any other failure (API error, bad input, mixed RAW/JPEG, etc.) |
+
+Example:
+
+```bash
+imagen --json profiles | jq '.[0].profile_key'
+```
+
+```bash
+if imagen --json edit ./raws --profile 328 > result.json; then
+  jq -r '.downloaded_files[]' result.json
+else
+  jq -r '.message' result.json >&2   # error detail on stderr
+fi
+```
+
+---
+
+## For AI agents
+
+An installable skill (`skills/imagen-cli/SKILL.md`) teaches agents to drive this
+CLI: always use `--json`, check exit codes, and discover capabilities via
+`--help` rather than hardcoding commands.

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -4,6 +4,10 @@
 
 Transform your post-production workflow with AI-powered batch editing. Upload hundreds of photos, apply professional edits automatically, and get download links in minutes.
 
+> **Prefer the command line?** This package also ships the `imagen` CLI — a
+> standalone binary (no Python required) that wraps the full API with `--json`
+> output for scripts and AI agents. See [`../../docs/CLI.md`](../../docs/CLI.md).
+
 ---
 
 ## ⚡ Quick start

--- a/sdks/python/imagen_sdk/__init__.py
+++ b/sdks/python/imagen_sdk/__init__.py
@@ -128,7 +128,7 @@ from .models import (
 )
 
 # Version info
-__version__ = "1.1.0"
+__version__ = "1.1.1"
 __author__ = "Shahar Polak"
 __email__ = "shahar@imagen-ai.com"
 __description__ = "A robust, Pydantic-powered SDK for the Imagen AI photo editing workflow"

--- a/sdks/python/imagen_sdk/cli.py
+++ b/sdks/python/imagen_sdk/cli.py
@@ -1,0 +1,427 @@
+"""Agent-native command-line interface for the Imagen AI SDK.
+
+Design goals (see docs/plans): a thin, non-interactive wrapper over the SDK that
+is equally usable by humans and AI agents.
+
+- Every command accepts ``--json`` for machine-readable output (a single JSON
+  document on stdout); errors in JSON mode are ``{"error": ..., "message": ...}``
+  on stderr with a non-zero exit code.
+- No interactive prompts. Missing required input is a hard error, never a prompt.
+- API key resolves from ``--api-key`` > ``IMAGEN_API_KEY`` env > ``~/.imagen/config.json``.
+
+ponytail: one file. It's a flat command surface over an existing SDK; splitting
+it buys nothing until it grows past ~800 lines.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from pathlib import Path
+from typing import Any, Callable, NoReturn
+
+import click
+
+from . import __version__
+from .enums import PhotographyType
+from .exceptions import AuthenticationError, ImagenError
+from .imagen_sdk import (
+    DEFAULT_BASE_URL,
+    JPG_EXTENSIONS,
+    RAW_EXTENSIONS,
+    SUPPORTED_FILE_FORMATS,
+    ImagenClient,
+    get_ai_tools,
+    get_profiles,
+    get_sky_replacement_templates,
+    list_projects,
+    quick_edit,
+)
+from .models import EditOptions, I2IEditOptions
+
+CONFIG_PATH = Path.home() / ".imagen" / "config.json"
+
+# --------------------------------------------------------------------------- #
+# config file                                                                 #
+# --------------------------------------------------------------------------- #
+
+
+def _load_config() -> dict[str, Any]:
+    try:
+        return json.loads(CONFIG_PATH.read_text())
+    except (FileNotFoundError, json.JSONDecodeError):
+        return {}
+
+
+def _save_config(cfg: dict[str, Any]) -> None:
+    CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    CONFIG_PATH.write_text(json.dumps(cfg, indent=2) + "\n")
+
+
+# --------------------------------------------------------------------------- #
+# output helpers                                                              #
+# --------------------------------------------------------------------------- #
+
+
+def _emit(ctx: dict[str, Any], data: Any, human: Callable[[Any], None]) -> None:
+    """Render a result. JSON mode dumps a plain-data form; human mode gets the raw object."""
+    if ctx["json"]:
+        click.echo(json.dumps(_dump(data), indent=2, default=str))
+    else:
+        human(data)
+
+
+def _fail(ctx: dict[str, Any], kind: str, message: str, code: int) -> NoReturn:
+    if ctx["json"]:
+        click.echo(json.dumps({"error": kind, "message": message}), err=True)
+    else:
+        click.secho(f"Error: {message}", fg="red", err=True)
+    raise SystemExit(code)
+
+
+def _run(ctx: dict[str, Any], coro: Any) -> Any:
+    """Run an SDK coroutine, mapping SDK errors to stable exit codes.
+
+    2 = authentication, 1 = any other failure.
+    """
+    try:
+        return asyncio.run(coro)
+    except AuthenticationError as exc:
+        _fail(ctx, "authentication", str(exc), 2)
+    except ImagenError as exc:
+        _fail(ctx, "api", str(exc), 1)
+    except click.ClickException:
+        raise
+    except Exception as exc:  # noqa: BLE001 - top-level guard for a CLI boundary
+        _fail(ctx, "error", str(exc), 1)
+
+
+def _dump(obj: Any) -> Any:
+    """Best-effort conversion of pydantic models / lists to plain JSON data."""
+    if isinstance(obj, list):
+        return [_dump(o) for o in obj]
+    if hasattr(obj, "model_dump"):
+        return obj.model_dump(mode="json")
+    return obj
+
+
+def _resolve_api_key(ctx: dict[str, Any]) -> str:
+    key = ctx["api_key"] or os.environ.get("IMAGEN_API_KEY") or _load_config().get("api_key")
+    if not key:
+        _fail(ctx, "config", "No API key. Pass --api-key, set IMAGEN_API_KEY, or run `imagen config --api-key <key>`.", 2)
+    return key
+
+
+def _gather_images(ctx: dict[str, Any], path_str: str) -> list[Path]:
+    """Expand a file or a top-level folder into a same-type list of image paths."""
+    path = Path(path_str)
+    if not path.exists():
+        _fail(ctx, "input", f"Path does not exist: {path}", 1)
+    if path.is_file():
+        files = [path]
+    else:
+        files = sorted(f for f in path.iterdir() if f.is_file() and f.suffix.lower() in SUPPORTED_FILE_FORMATS)
+    if not files:
+        _fail(ctx, "input", f"No supported image files found in {path}", 1)
+
+    raws = [f for f in files if f.suffix.lower() in RAW_EXTENSIONS]
+    jpgs = [f for f in files if f.suffix.lower() in JPG_EXTENSIONS]
+    if raws and jpgs:
+        _fail(
+            ctx,
+            "input",
+            "Folder mixes RAW and JPEG files, which cannot share a project. Run separately on RAW-only and JPEG-only folders.",
+            1,
+        )
+    return files
+
+
+# --------------------------------------------------------------------------- #
+# root group                                                                  #
+# --------------------------------------------------------------------------- #
+
+
+@click.group(context_settings={"help_option_names": ["-h", "--help"]})
+@click.version_option(__version__, "-V", "--version", prog_name="imagen")
+@click.option("--api-key", default=None, help="Imagen API key (else IMAGEN_API_KEY or config).")
+@click.option("--base-url", default=None, help=f"API base URL (default: {DEFAULT_BASE_URL}).")
+@click.option("--json", "json_mode", is_flag=True, help="Emit machine-readable JSON on stdout.")
+@click.pass_context
+def cli(ctx: click.Context, api_key: str | None, base_url: str | None, json_mode: bool) -> None:
+    """Imagen AI — agent-native photo editing CLI.
+
+    Run any command with --json for machine-readable output. See `imagen COMMAND --help`.
+    """
+    cfg = _load_config()
+    ctx.obj = {
+        "api_key": api_key,
+        "base_url": base_url or cfg.get("base_url") or DEFAULT_BASE_URL,
+        "json": json_mode,
+    }
+
+
+# --------------------------------------------------------------------------- #
+# read commands                                                               #
+# --------------------------------------------------------------------------- #
+
+
+@cli.command()
+@click.pass_obj
+def profiles(ctx: dict[str, Any]) -> None:
+    """List your editing profiles (use profile_key with `edit`)."""
+    key = _resolve_api_key(ctx)
+    result = _run(ctx, get_profiles(key, ctx["base_url"]))
+
+    def human(items: list[Any]) -> None:
+        if not items:
+            click.echo("No profiles found.")
+            return
+        for p in items:
+            click.echo(f"{p.profile_key:>8}  {p.image_type:<6}  {p.profile_type:<10}  {p.profile_name}")
+
+    _emit(ctx, result, human)
+
+
+@cli.command()
+@click.option("--size", default=20, show_default=True, help="Page size (1-100).")
+@click.option("--page", default=0, show_default=True, help="Zero-based page index.")
+@click.pass_obj
+def projects(ctx: dict[str, Any], size: int, page: int) -> None:
+    """List projects in your account."""
+    key = _resolve_api_key(ctx)
+    result = _run(ctx, list_projects(key, size=size, page=page, base_url=ctx["base_url"]))
+
+    def human(resp: Any) -> None:
+        for item in resp.projects:
+            name = item.name or "(unnamed)"
+            click.echo(f"{item.project_uuid}  {item.status:<12}  {item.number_of_images:>4} img  {name}")
+
+    _emit(ctx, result, human)
+
+
+@cli.command(name="sky-templates")
+@click.pass_obj
+def sky_templates(ctx: dict[str, Any]) -> None:
+    """List sky replacement templates (id -> --sky-template-id)."""
+    key = _resolve_api_key(ctx)
+    result = _run(ctx, get_sky_replacement_templates(key, ctx["base_url"]))
+
+    def human(items: list[Any]) -> None:
+        for t in items:
+            click.echo(f"{t.id:>6}  {'default' if t.is_default else ''}")
+
+    _emit(ctx, result, human)
+
+
+@cli.command(name="ai-tools")
+@click.argument("project_uuid")
+@click.pass_obj
+def ai_tools(ctx: dict[str, Any], project_uuid: str) -> None:
+    """List AI quick tools available for a project (enhancement_type -> --tool-id)."""
+    key = _resolve_api_key(ctx)
+    result = _run(ctx, get_ai_tools(key, project_uuid, ctx["base_url"]))
+    _emit(ctx, result, lambda r: click.echo(json.dumps(_dump(r), indent=2)))
+
+
+# --------------------------------------------------------------------------- #
+# edit (quick_edit) — the headline command                                    #
+# --------------------------------------------------------------------------- #
+
+_PHOTO_TYPES = [t.value for t in PhotographyType]
+
+
+@cli.command()
+@click.argument("folder")
+@click.option("--profile", "profile_key", type=int, default=None, help="Profile key (see `imagen profiles`).")
+@click.option(
+    "--type",
+    "photo_type",
+    type=click.Choice(_PHOTO_TYPES, case_sensitive=False),
+    default=None,
+    help="Photography type for AI optimization.",
+)
+@click.option("--name", "project_name", default=None, help="Project name (must be unique).")
+@click.option("--out", "download_dir", default="downloads", show_default=True, help="Download directory.")
+@click.option("--export/--no-export", default=False, help="Also export final JPEGs.")
+@click.option("--download/--no-download", "download", default=True, show_default=True, help="Download results locally.")
+# editing options (EditOptions)
+@click.option("--crop", is_flag=True, default=None)
+@click.option("--straighten", is_flag=True, default=None)
+@click.option("--hdr-merge", is_flag=True, default=None)
+@click.option("--portrait-crop", is_flag=True, default=None)
+@click.option("--smooth-skin", is_flag=True, default=None)
+@click.option("--subject-mask", is_flag=True, default=None)
+@click.option("--headshot-crop", is_flag=True, default=None)
+@click.option("--perspective-correction", is_flag=True, default=None)
+@click.option("--sky-replacement", is_flag=True, default=None)
+@click.option("--sky-template-id", type=int, default=None)
+@click.option("--window-pull", is_flag=True, default=None)
+@click.option("--crop-aspect-ratio", default=None, help="e.g. 2X3, 4X5, 5X7.")
+@click.pass_obj
+def edit(
+    ctx: dict[str, Any],
+    folder: str,
+    profile_key: int | None,
+    photo_type: str | None,
+    project_name: str | None,
+    download_dir: str,
+    export: bool,
+    download: bool,
+    **edit_flags: Any,
+) -> None:
+    """Edit a folder (or single file) of RAW/JPEG photos with your AI profile.
+
+    Runs the full workflow: create project, upload, edit, and optionally
+    export + download. All files must be the same type (all RAW or all JPEG).
+    """
+    key = _resolve_api_key(ctx)
+    profile_key = profile_key if profile_key is not None else _load_config().get("profile")
+    if profile_key is None:
+        _fail(ctx, "config", "No profile. Pass --profile or run `imagen config --profile <key>`.", 2)
+
+    images = _gather_images(ctx, folder)
+    edit_options = EditOptions(**{k: v for k, v in edit_flags.items() if v is not None})
+    ptype = PhotographyType(photo_type.upper()) if photo_type else None
+
+    result = _run(
+        ctx,
+        quick_edit(
+            api_key=key,
+            profile_key=int(profile_key),
+            image_paths=[str(p) for p in images],
+            project_name=project_name,
+            photography_type=ptype,
+            export=export,
+            edit_options=edit_options,
+            download=download,
+            download_dir=download_dir,
+            base_url=ctx["base_url"],
+        ),
+    )
+
+    def human(res: Any) -> None:
+        s = res.upload_summary
+        click.echo(f"Project: {res.project_uuid}")
+        click.echo(f"Uploaded: {s.successful}/{s.total} (failed {s.failed})")
+        click.echo(f"Edited links: {len(res.download_links)}")
+        if res.downloaded_files:
+            click.echo(f"Downloaded: {len(res.downloaded_files)} -> {download_dir}")
+        if res.exported_files:
+            click.echo(f"Exported: {len(res.exported_files)}")
+
+    _emit(ctx, result, human)
+
+
+# --------------------------------------------------------------------------- #
+# enhance (AI quick tool on an edited image)                                  #
+# --------------------------------------------------------------------------- #
+
+
+@cli.command()
+@click.argument("project_uuid")
+@click.argument("filename")
+@click.option("--tool-id", required=True, help="AI tool id (see `imagen ai-tools <project>`).")
+@click.option("--parent-version-id", type=int, default=None, help="Version to base the enhancement on.")
+@click.pass_obj
+def enhance(ctx: dict[str, Any], project_uuid: str, filename: str, tool_id: str, parent_version_id: int | None) -> None:
+    """Apply an AI quick tool to an already-edited image."""
+    key = _resolve_api_key(ctx)
+
+    async def _do() -> Any:
+        async with ImagenClient(key, ctx["base_url"]) as client:
+            return await client.enhance_image(project_uuid, filename, tool_id, parent_version_id=parent_version_id)
+
+    result = _run(ctx, _do())
+    _emit(ctx, result, lambda r: click.echo(json.dumps(_dump(r), indent=2)))
+
+
+# --------------------------------------------------------------------------- #
+# i2i (image-to-image) workflow                                               #
+# --------------------------------------------------------------------------- #
+
+
+@cli.command()
+@click.argument("folder")
+@click.option("--name", "project_name", default=None, help="Project name.")
+@click.option("--out", "download_dir", default="downloads", show_default=True, help="Download directory.")
+@click.option("--download/--no-download", "download", default=True, show_default=True)
+@click.option("--hdr-merge", is_flag=True, default=None)
+@click.option("--sky-replacement", is_flag=True, default=None)
+@click.option("--sky-template-id", type=int, default=None)
+@click.option("--perspective-correction", is_flag=True, default=None)
+@click.pass_obj
+def i2i(ctx: dict[str, Any], folder: str, project_name: str | None, download_dir: str, download: bool, **edit_flags: Any) -> None:
+    """Run the image-to-image (i2i) editing workflow on a folder of photos."""
+    key = _resolve_api_key(ctx)
+    images = _gather_images(ctx, folder)
+    edit_options = I2IEditOptions(**{k: v for k, v in edit_flags.items() if v is not None})
+
+    async def _do() -> dict[str, Any]:
+        async with ImagenClient(key, ctx["base_url"]) as client:
+            project_uuid = await client.create_i2i_project(project_name)
+            summary = await client.upload_i2i_images(project_uuid, [str(p) for p in images])
+            await client.start_i2i_editing(project_uuid, edit_options)
+            await client.wait_for_i2i_completion(project_uuid)
+            links = await client.get_i2i_download_links(project_uuid)
+            downloaded = None
+            if download:
+                downloaded = await client.download_files(links, download_dir)
+            return {
+                "project_uuid": project_uuid,
+                "upload_summary": _dump(summary),
+                "download_links": links,
+                "downloaded_files": downloaded,
+            }
+
+    result = _run(ctx, _do())
+
+    def human(res: dict[str, Any]) -> None:
+        click.echo(f"Project: {res['project_uuid']}")
+        click.echo(f"Edited links: {len(res['download_links'])}")
+        if res["downloaded_files"]:
+            click.echo(f"Downloaded: {len(res['downloaded_files'])} -> {download_dir}")
+
+    _emit(ctx, result, human)  # i2i already returns plain JSON data
+
+
+# --------------------------------------------------------------------------- #
+# config                                                                      #
+# --------------------------------------------------------------------------- #
+
+
+@cli.command()
+@click.option("--api-key", default=None, help="Store an API key.")
+@click.option("--profile", type=int, default=None, help="Store a default profile key.")
+@click.option("--base-url", default=None, help="Store a default base URL.")
+@click.pass_obj
+def config(ctx: dict[str, Any], api_key: str | None, profile: int | None, base_url: str | None) -> None:
+    """Show or set persisted defaults (~/.imagen/config.json)."""
+    cfg = _load_config()
+    updates = {"api_key": api_key, "profile": profile, "base_url": base_url}
+    updates = {k: v for k, v in updates.items() if v is not None}
+    if updates:
+        cfg.update(updates)
+        _save_config(cfg)
+
+    # Never echo the raw API key back; report presence only.
+    view = dict(cfg)
+    if "api_key" in view:
+        view["api_key"] = "***set***"
+
+    def human(v: dict[str, Any]) -> None:
+        if not v:
+            click.echo("No config set.")
+            return
+        for k, val in v.items():
+            click.echo(f"{k} = {val}")
+
+    _emit(ctx, view, human)
+
+
+def main() -> None:
+    cli()
+
+
+if __name__ == "__main__":
+    main()

--- a/sdks/python/imagen_sdk/cli.py
+++ b/sdks/python/imagen_sdk/cli.py
@@ -18,14 +18,16 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import sys
 from pathlib import Path
-from typing import Any, Callable, NoReturn
+from typing import Any, Callable, NoReturn, TypeVar
 
 import click
+from pydantic import BaseModel, ValidationError
 
 from . import __version__
 from .enums import PhotographyType
-from .exceptions import AuthenticationError, ImagenError
+from .exceptions import AuthenticationError, ImagenError, UploadError
 from .imagen_sdk import (
     DEFAULT_BASE_URL,
     JPG_EXTENSIONS,
@@ -55,8 +57,12 @@ def _load_config() -> dict[str, Any]:
 
 
 def _save_config(cfg: dict[str, Any]) -> None:
+    # Write atomically so a crash or a concurrent `imagen config` can't leave a
+    # truncated file that _load_config would then silently reset to {}.
     CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
-    CONFIG_PATH.write_text(json.dumps(cfg, indent=2) + "\n")
+    tmp = CONFIG_PATH.with_name(CONFIG_PATH.name + ".tmp")
+    tmp.write_text(json.dumps(cfg, indent=2) + "\n")
+    os.replace(tmp, CONFIG_PATH)
 
 
 # --------------------------------------------------------------------------- #
@@ -72,12 +78,16 @@ def _emit(ctx: dict[str, Any], data: Any, human: Callable[[Any], None]) -> None:
         human(data)
 
 
-def _fail(ctx: dict[str, Any], kind: str, message: str, code: int) -> NoReturn:
-    if ctx["json"]:
+def _emit_error(json_mode: bool, kind: str, message: str, code: int) -> NoReturn:
+    if json_mode:
         click.echo(json.dumps({"error": kind, "message": message}), err=True)
     else:
         click.secho(f"Error: {message}", fg="red", err=True)
     raise SystemExit(code)
+
+
+def _fail(ctx: dict[str, Any], kind: str, message: str, code: int) -> NoReturn:
+    _emit_error(ctx["json"], kind, message, code)
 
 
 def _run(ctx: dict[str, Any], coro: Any) -> Any:
@@ -107,10 +117,27 @@ def _dump(obj: Any) -> Any:
 
 
 def _resolve_api_key(ctx: dict[str, Any]) -> str:
-    key = ctx["api_key"] or os.environ.get("IMAGEN_API_KEY") or _load_config().get("api_key")
+    raw = ctx["api_key"] or os.environ.get("IMAGEN_API_KEY") or _load_config().get("api_key") or ""
+    key = raw.strip()
     if not key:
         _fail(ctx, "config", "No API key. Pass --api-key, set IMAGEN_API_KEY, or run `imagen config --api-key <key>`.", 2)
     return key
+
+
+_M = TypeVar("_M", bound=BaseModel)
+
+
+def _build_options(ctx: dict[str, Any], model: type[_M], flags: dict[str, Any]) -> _M:
+    """Construct an option model, mapping validation errors to a JSON `input` error.
+
+    Without this, e.g. `--crop --portrait-crop` (mutually exclusive) would raise an
+    uncaught ValidationError instead of honoring the CLI's JSON/exit-code contract.
+    """
+    try:
+        return model(**{k: v for k, v in flags.items() if v is not None})
+    except ValidationError as exc:
+        msg = "; ".join(e.get("msg", "") for e in exc.errors()) or str(exc)
+        _fail(ctx, "input", msg, 1)
 
 
 def _gather_images(ctx: dict[str, Any], path_str: str) -> list[Path]:
@@ -119,6 +146,8 @@ def _gather_images(ctx: dict[str, Any], path_str: str) -> list[Path]:
     if not path.exists():
         _fail(ctx, "input", f"Path does not exist: {path}", 1)
     if path.is_file():
+        if path.suffix.lower() not in SUPPORTED_FILE_FORMATS:
+            _fail(ctx, "input", f"Unsupported file type: {path.name}", 1)
         files = [path]
     else:
         files = sorted(f for f in path.iterdir() if f.is_file() and f.suffix.lower() in SUPPORTED_FILE_FORMATS)
@@ -255,7 +284,7 @@ _PHOTO_TYPES = [t.value for t in PhotographyType]
 @click.option("--headshot-crop", is_flag=True, default=None)
 @click.option("--perspective-correction", is_flag=True, default=None)
 @click.option("--sky-replacement", is_flag=True, default=None)
-@click.option("--sky-template-id", type=int, default=None)
+@click.option("--sky-template-id", "sky_replacement_template_id", type=int, default=None)
 @click.option("--window-pull", is_flag=True, default=None)
 @click.option("--crop-aspect-ratio", default=None, help="e.g. 2X3, 4X5, 5X7.")
 @click.pass_obj
@@ -281,7 +310,7 @@ def edit(
         _fail(ctx, "config", "No profile. Pass --profile or run `imagen config --profile <key>`.", 2)
 
     images = _gather_images(ctx, folder)
-    edit_options = EditOptions(**{k: v for k, v in edit_flags.items() if v is not None})
+    edit_options = _build_options(ctx, EditOptions, edit_flags)
     ptype = PhotographyType(photo_type.upper()) if photo_type else None
 
     result = _run(
@@ -348,19 +377,21 @@ def enhance(ctx: dict[str, Any], project_uuid: str, filename: str, tool_id: str,
 @click.option("--download/--no-download", "download", default=True, show_default=True)
 @click.option("--hdr-merge", is_flag=True, default=None)
 @click.option("--sky-replacement", is_flag=True, default=None)
-@click.option("--sky-template-id", type=int, default=None)
+@click.option("--sky-template-id", "sky_replacement_template_id", type=int, default=None)
 @click.option("--perspective-correction", is_flag=True, default=None)
 @click.pass_obj
 def i2i(ctx: dict[str, Any], folder: str, project_name: str | None, download_dir: str, download: bool, **edit_flags: Any) -> None:
     """Run the image-to-image (i2i) editing workflow on a folder of photos."""
     key = _resolve_api_key(ctx)
     images = _gather_images(ctx, folder)
-    edit_options = I2IEditOptions(**{k: v for k, v in edit_flags.items() if v is not None})
+    edit_options = _build_options(ctx, I2IEditOptions, edit_flags)
 
     async def _do() -> dict[str, Any]:
         async with ImagenClient(key, ctx["base_url"]) as client:
             project_uuid = await client.create_i2i_project(project_name)
             summary = await client.upload_i2i_images(project_uuid, [str(p) for p in images])
+            if summary.successful == 0:
+                raise UploadError("No images uploaded successfully; not starting i2i editing.")
             await client.start_i2i_editing(project_uuid, edit_options)
             await client.wait_for_i2i_completion(project_uuid)
             links = await client.get_i2i_download_links(project_uuid)
@@ -420,7 +451,22 @@ def config(ctx: dict[str, Any], api_key: str | None, profile: int | None, base_u
 
 
 def main() -> None:
-    cli()
+    """Entry point that keeps Click parse errors inside the CLI's contract.
+
+    Click's own usage errors would otherwise print human text and exit 2 (which
+    we reserve for auth/config). We run non-standalone and normalize: usage/parse
+    errors become a JSON `input` error (in --json mode) with exit code 1. Errors
+    raised by commands themselves already exit via `_fail` and propagate here.
+    """
+    json_mode = "--json" in sys.argv[1:]
+    try:
+        code = cli.main(standalone_mode=False)
+    except (click.UsageError, click.ClickException) as exc:
+        _emit_error(json_mode, "input", exc.format_message(), 1)
+    except click.exceptions.Abort:
+        _emit_error(json_mode, "error", "Aborted.", 1)
+    else:
+        sys.exit(code or 0)
 
 
 if __name__ == "__main__":

--- a/sdks/python/packaging/build.sh
+++ b/sdks/python/packaging/build.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+# Build the standalone `imagen` binary from the current SDK source with PyInstaller.
+# Single source of truth for the build — CI (release-cli.yml) and local devs both
+# call this, so a locally built binary matches what CI ships.
+#
+# Usage:  sh packaging/build.sh        (run from sdks/python, or anywhere)
+# Output: sdks/python/dist/imagen  (or dist/imagen.exe on Windows)
+#
+# Requires PyInstaller: pip install pyinstaller
+set -eu
+
+# Resolve to sdks/python regardless of caller's cwd.
+cd "$(dirname "$0")/.."
+
+if ! python -c "import PyInstaller" >/dev/null 2>&1; then
+  echo "PyInstaller not found. Install it: pip install pyinstaller" >&2
+  exit 1
+fi
+
+python -m PyInstaller \
+  --onefile \
+  --name imagen \
+  --clean --noconfirm \
+  --paths . \
+  --collect-submodules imagen_sdk \
+  packaging/imagen_entry.py
+
+echo "Built: $(pwd)/dist/imagen"

--- a/sdks/python/packaging/imagen_entry.py
+++ b/sdks/python/packaging/imagen_entry.py
@@ -1,0 +1,7 @@
+"""PyInstaller entry point. Uses an absolute import so the package's own
+relative imports resolve when frozen into a single binary."""
+
+from imagen_sdk.cli import main
+
+if __name__ == "__main__":
+    main()

--- a/sdks/python/packaging/install.sh
+++ b/sdks/python/packaging/install.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+# Install the `imagen` CLI: downloads the standalone binary for this platform
+# from the latest GitHub release. No Python required.
+#
+#   curl -fsSL https://raw.githubusercontent.com/imagenai/imagen-ai-sdk/master/sdks/python/packaging/install.sh | sh
+#
+# Env overrides: IMAGEN_INSTALL_DIR (default: ~/.local/bin), IMAGEN_VERSION (default: latest).
+set -eu
+
+REPO="imagenai/imagen-ai-sdk"
+INSTALL_DIR="${IMAGEN_INSTALL_DIR:-$HOME/.local/bin}"
+
+os="$(uname -s)"
+arch="$(uname -m)"
+case "$os" in
+  Darwin) plat="macos" ;;
+  Linux)  plat="linux" ;;
+  *) echo "Unsupported OS: $os (Windows: download imagen-windows-x64.exe from the release)" >&2; exit 1 ;;
+esac
+case "$arch" in
+  x86_64|amd64) a="x64" ;;
+  arm64|aarch64) a="arm64" ;;
+  *) echo "Unsupported architecture: $arch" >&2; exit 1 ;;
+esac
+
+asset="imagen-${plat}-${a}"
+if [ "${IMAGEN_VERSION:-latest}" = "latest" ]; then
+  url="https://github.com/${REPO}/releases/latest/download/${asset}"
+else
+  url="https://github.com/${REPO}/releases/download/${IMAGEN_VERSION}/${asset}"
+fi
+
+echo "Installing imagen (${asset}) -> ${INSTALL_DIR}/imagen"
+mkdir -p "$INSTALL_DIR"
+if ! curl -fsSL "$url" -o "$INSTALL_DIR/imagen"; then
+  echo "Download failed: $url" >&2
+  echo "Check available assets at https://github.com/${REPO}/releases" >&2
+  exit 1
+fi
+chmod +x "$INSTALL_DIR/imagen"
+
+if ! command -v imagen >/dev/null 2>&1; then
+  echo "Installed, but $INSTALL_DIR is not on your PATH. Add it:"
+  echo "  export PATH=\"$INSTALL_DIR:\$PATH\""
+fi
+echo "Done. Run: imagen --help"

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -29,7 +29,11 @@ dependencies = [
     "httpx>=0.24.0",
     "aiofiles>=23.0.0",
     "pydantic>=2.0.0",
+    "click>=8.1.0",
 ]
+
+[project.scripts]
+imagen = "imagen_sdk.cli:main"
 
 [project.optional-dependencies]
 dev = [

--- a/sdks/python/tests/test_cli.py
+++ b/sdks/python/tests/test_cli.py
@@ -5,6 +5,7 @@ contract: JSON vs human output, exit codes, argument -> SDK mapping, and config.
 """
 
 import json
+import sys
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
@@ -14,7 +15,28 @@ from click.testing import CliRunner
 from imagen_sdk import cli as cli_mod
 from imagen_sdk.cli import cli
 from imagen_sdk.enums import PhotographyType
-from imagen_sdk.models import Profile, QuickEditResult, UploadResult, UploadSummary
+from imagen_sdk.models import (
+    EnhanceResult,
+    PaginationInfo,
+    Profile,
+    ProjectListItem,
+    ProjectListResponse,
+    QuickEditResult,
+    SkyTemplate,
+    UploadResult,
+    UploadSummary,
+)
+
+
+def _client_cm(**method_returns):
+    """Build a mock that behaves as `async with ImagenClient(...) as client`."""
+    client = AsyncMock()
+    for name, value in method_returns.items():
+        getattr(client, name).return_value = value
+    cm = AsyncMock()
+    cm.__aenter__.return_value = client
+    return cm, client
+
 
 pytestmark = pytest.mark.unit
 
@@ -128,6 +150,134 @@ def test_config_masks_api_key(runner):
     # persisted on disk with the real value
     stored = json.loads(Path(cli_mod.CONFIG_PATH).read_text())
     assert stored["api_key"] == "SECRET"
+
+
+def test_edit_sky_template_id_maps_to_model_field(runner, tmp_path):
+    """Regression: --sky-template-id must reach EditOptions.sky_replacement_template_id."""
+    (tmp_path / "photo.jpg").touch()
+    fake = QuickEditResult(
+        project_uuid="u",
+        upload_summary=UploadSummary(total=1, successful=1, failed=0, results=[]),
+        download_links=[],
+    )
+    mock = AsyncMock(return_value=fake)
+    with patch.object(cli_mod, "quick_edit", mock):
+        result = runner.invoke(
+            cli,
+            ["--api-key", "k", "--json", "edit", str(tmp_path), "--profile", "1", "--sky-replacement", "--sky-template-id", "77"],
+        )
+    assert result.exit_code == 0, result.output
+    opts = mock.call_args.kwargs["edit_options"]
+    assert opts.sky_replacement_template_id == 77
+    assert opts.to_api_dict().get("sky_replacement_template_id") == 77
+
+
+def test_edit_mutually_exclusive_flags_json_error(runner, tmp_path):
+    (tmp_path / "photo.jpg").touch()
+    result = runner.invoke(
+        cli,
+        ["--api-key", "k", "--json", "edit", str(tmp_path), "--profile", "1", "--crop", "--portrait-crop"],
+    )
+    assert result.exit_code == 1
+    assert json.loads(result.output)["error"] == "input"
+
+
+def test_edit_unsupported_single_file(runner, tmp_path):
+    f = tmp_path / "notes.txt"
+    f.touch()
+    result = runner.invoke(cli, ["--api-key", "k", "--json", "edit", str(f), "--profile", "1"])
+    assert result.exit_code == 1
+    assert json.loads(result.output)["error"] == "input"
+
+
+def test_usage_error_is_json_and_exit_1(monkeypatch, capsys):
+    """Click's own parse errors must honor the JSON/exit-code contract (not exit 2).
+
+    Goes through main() (not CliRunner), since the normalization lives there.
+    """
+    monkeypatch.setattr(sys, "argv", ["imagen", "--api-key", "k", "--json", "enhance", "proj", "file"])
+    with pytest.raises(SystemExit) as se:
+        cli_mod.main()
+    assert se.value.code == 1
+    payload = json.loads(capsys.readouterr().err)
+    assert payload["error"] == "input"
+    assert "tool-id" in payload["message"]
+
+
+def test_whitespace_api_key_treated_as_missing(runner):
+    result = runner.invoke(cli, ["--api-key", "   ", "--json", "profiles"])
+    assert result.exit_code == 2
+    assert json.loads(result.output)["error"] == "config"
+
+
+def test_projects_json(runner):
+    resp = ProjectListResponse(
+        projects=[ProjectListItem(project_uuid="abc", status="Completed", created_at="t", number_of_images=3, customer_reference_id=100)],
+        pagination=PaginationInfo(total=1, size=20, page=0),
+    )
+    with patch.object(cli_mod, "list_projects", AsyncMock(return_value=resp)):
+        result = runner.invoke(cli, ["--api-key", "k", "--json", "projects"])
+    assert result.exit_code == 0
+    assert json.loads(result.output)["projects"][0]["project_uuid"] == "abc"
+
+
+def test_sky_templates_json(runner):
+    with patch.object(cli_mod, "get_sky_replacement_templates", AsyncMock(return_value=[SkyTemplate(id=3, is_default=True)])):
+        result = runner.invoke(cli, ["--api-key", "k", "--json", "sky-templates"])
+    assert result.exit_code == 0
+    assert json.loads(result.output)[0]["id"] == 3
+
+
+def test_ai_tools_json(runner):
+    from imagen_sdk.models import AIToolsResponse
+
+    with patch.object(cli_mod, "get_ai_tools", AsyncMock(return_value=AIToolsResponse(prompts=[]))):
+        result = runner.invoke(cli, ["--api-key", "k", "--json", "ai-tools", "proj-uuid"])
+    assert result.exit_code == 0
+    assert "prompts" in json.loads(result.output)
+
+
+def test_enhance_calls_client(runner):
+    cm, client = _client_cm(enhance_image=EnhanceResult(status="COMPLETED", enhanced_image_url="http://x/e.jpg"))
+    with patch.object(cli_mod, "ImagenClient", return_value=cm):
+        result = runner.invoke(cli, ["--api-key", "k", "--json", "enhance", "proj", "img.jpg", "--tool-id", "SHARPEN"])
+    assert result.exit_code == 0, result.output
+    client.enhance_image.assert_awaited_once()
+    args, kwargs = client.enhance_image.call_args
+    assert args[:3] == ("proj", "img.jpg", "SHARPEN")
+
+
+def test_i2i_happy_path(runner, tmp_path):
+    (tmp_path / "a.jpg").touch()
+    cm, client = _client_cm(
+        create_i2i_project="i2i-uuid",
+        upload_i2i_images=UploadSummary(total=1, successful=1, failed=0, results=[]),
+        get_i2i_download_links=["http://x/1"],
+        download_files=["/out/a.jpg"],
+    )
+    with patch.object(cli_mod, "ImagenClient", return_value=cm):
+        result = runner.invoke(cli, ["--api-key", "k", "--json", "i2i", str(tmp_path), "--out", "/out"])
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert data["project_uuid"] == "i2i-uuid"
+    client.start_i2i_editing.assert_awaited_once()
+
+
+def test_i2i_aborts_when_all_uploads_fail(runner, tmp_path):
+    (tmp_path / "a.jpg").touch()
+    cm, client = _client_cm(
+        create_i2i_project="i2i-uuid",
+        upload_i2i_images=UploadSummary(
+            total=1,
+            successful=0,
+            failed=1,
+            results=[UploadResult(file="a.jpg", success=False, error="boom")],
+        ),
+    )
+    with patch.object(cli_mod, "ImagenClient", return_value=cm):
+        result = runner.invoke(cli, ["--api-key", "k", "--json", "i2i", str(tmp_path)])
+    assert result.exit_code == 1
+    client.start_i2i_editing.assert_not_called()
 
 
 def test_config_value_used_as_fallback(runner):

--- a/sdks/python/tests/test_cli.py
+++ b/sdks/python/tests/test_cli.py
@@ -1,0 +1,145 @@
+"""Tests for the `imagen` CLI (imagen_sdk.cli).
+
+The CLI is a thin wrapper, so these tests mock the SDK layer and assert the CLI
+contract: JSON vs human output, exit codes, argument -> SDK mapping, and config.
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from imagen_sdk import cli as cli_mod
+from imagen_sdk.cli import cli
+from imagen_sdk.enums import PhotographyType
+from imagen_sdk.models import Profile, QuickEditResult, UploadResult, UploadSummary
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def isolated_config(tmp_path, monkeypatch):
+    """Point the config file at a temp location so tests never touch ~/.imagen."""
+    monkeypatch.setattr(cli_mod, "CONFIG_PATH", tmp_path / "config.json")
+    monkeypatch.delenv("IMAGEN_API_KEY", raising=False)
+
+
+def test_help(runner):
+    result = runner.invoke(cli, ["--help"])
+    assert result.exit_code == 0
+    assert "agent-native" in result.output
+
+
+def test_missing_api_key_json(runner):
+    result = runner.invoke(cli, ["--json", "profiles"])
+    assert result.exit_code == 2
+    payload = json.loads(result.output)
+    assert payload["error"] == "config"
+
+
+def test_profiles_json(runner):
+    fake = [Profile(image_type="RAW", profile_key=7, profile_name="Warm", profile_type="STYLE")]
+    with patch.object(cli_mod, "get_profiles", AsyncMock(return_value=fake)):
+        result = runner.invoke(cli, ["--api-key", "k", "--json", "profiles"])
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data[0]["profile_key"] == 7
+
+
+def test_profiles_human(runner):
+    fake = [Profile(image_type="RAW", profile_key=7, profile_name="Warm", profile_type="STYLE")]
+    with patch.object(cli_mod, "get_profiles", AsyncMock(return_value=fake)):
+        result = runner.invoke(cli, ["--api-key", "k", "profiles"])
+    assert result.exit_code == 0
+    assert "Warm" in result.output
+    assert not result.output.strip().startswith("[")  # not JSON
+
+
+def test_edit_mixed_folder_errors(runner, tmp_path):
+    (tmp_path / "a.cr2").touch()
+    (tmp_path / "b.jpg").touch()
+    result = runner.invoke(cli, ["--api-key", "k", "--json", "edit", str(tmp_path), "--profile", "1"])
+    assert result.exit_code == 1
+    assert json.loads(result.output)["error"] == "input"
+
+
+def test_edit_maps_args_to_quick_edit(runner, tmp_path):
+    (tmp_path / "photo.jpg").touch()
+    fake_result = QuickEditResult(
+        project_uuid="uuid-123",
+        upload_summary=UploadSummary(
+            total=1,
+            successful=1,
+            failed=0,
+            results=[UploadResult(file="photo.jpg", success=True)],
+        ),
+        download_links=["http://x/1"],
+    )
+    mock = AsyncMock(return_value=fake_result)
+    with patch.object(cli_mod, "quick_edit", mock):
+        result = runner.invoke(
+            cli,
+            [
+                "--api-key",
+                "k",
+                "--json",
+                "edit",
+                str(tmp_path),
+                "--profile",
+                "42",
+                "--type",
+                "wedding",
+                "--crop",
+                "--smooth-skin",
+            ],
+        )
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output)["project_uuid"] == "uuid-123"
+
+    kwargs = mock.call_args.kwargs
+    assert kwargs["profile_key"] == 42
+    assert kwargs["photography_type"] == PhotographyType.WEDDING
+    assert kwargs["edit_options"].crop is True
+    assert kwargs["edit_options"].smooth_skin is True
+    # untouched flags stay unset (None), never coerced to False
+    assert kwargs["edit_options"].straighten is None
+
+
+def test_edit_missing_profile_errors(runner, tmp_path):
+    (tmp_path / "photo.jpg").touch()
+    result = runner.invoke(cli, ["--api-key", "k", "--json", "edit", str(tmp_path)])
+    assert result.exit_code == 2
+    assert json.loads(result.output)["error"] == "config"
+
+
+def test_config_masks_api_key(runner):
+    set_result = runner.invoke(cli, ["--json", "config", "--api-key", "SECRET", "--profile", "9"])
+    assert set_result.exit_code == 0
+    view = json.loads(set_result.output)
+    assert view["api_key"] == "***set***"
+    assert view["profile"] == 9
+    # persisted on disk with the real value
+    stored = json.loads(Path(cli_mod.CONFIG_PATH).read_text())
+    assert stored["api_key"] == "SECRET"
+
+
+def test_config_value_used_as_fallback(runner):
+    runner.invoke(cli, ["config", "--api-key", "FROMFILE"])
+    fake = []
+    seen = {}
+
+    async def _capture(api_key, base_url):
+        seen["api_key"] = api_key
+        return fake
+
+    with patch.object(cli_mod, "get_profiles", _capture):
+        result = runner.invoke(cli, ["--json", "profiles"])
+    assert result.exit_code == 0
+    assert seen["api_key"] == "FROMFILE"

--- a/skills/imagen-cli/SKILL.md
+++ b/skills/imagen-cli/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: imagen-cli
+description: "Use whenever an agent or user needs to edit, cull, or process photos with Imagen AI from the command line. Triggers on: 'edit my photos', 'run imagen', 'use the imagen CLI', 'AI edit these RAW/JPEG files', 'batch process wedding/portrait/real-estate photos', 'list my imagen profiles/projects', 'enhance an edited image', 'image-to-image edit'. The `imagen` CLI is a single self-contained binary (no Python required) that wraps the full Imagen AI API. Prefer it over hand-writing SDK code."
+---
+
+# Imagen CLI (agent-native)
+
+`imagen` is a standalone binary wrapping the whole Imagen AI API. It is built to
+be driven by agents: non-interactive, `--json` output, stable exit codes, and
+fully self-describing via `--help`. **You do not need to memorize the command
+surface — discover it at runtime.**
+
+## First: make sure it's installed
+
+```bash
+imagen --version || curl -fsSL https://raw.githubusercontent.com/imagenai/imagen-ai-sdk/master/sdks/python/packaging/install.sh | sh
+```
+
+No Python is required — the binary bundles its own runtime.
+
+## Golden rules for agents
+
+1. **Always pass `--json`** for anything you parse. Output is a single JSON
+   document on stdout. Human tables are only for interactive users.
+2. **Check the exit code**: `0` success, `2` auth/config problem (bad or missing
+   key), `1` any other failure. In `--json` mode, failures print
+   `{"error": "...", "message": "..."}` on stderr.
+3. **Discover, don't guess.** Run `imagen --help` and `imagen <command> --help`
+   to see every command and flag. New capabilities appear here automatically.
+4. **Never invent flags.** If unsure, read `--help`.
+
+## Authentication
+
+API key resolution order: `--api-key` > `IMAGEN_API_KEY` env var > `~/.imagen/config.json`.
+
+```bash
+imagen config --api-key <KEY>       # persist it once
+imagen config --profile <KEY>       # optional default profile
+```
+
+## The command surface (run `--help` for the source of truth)
+
+| Command | Purpose |
+|---------|---------|
+| `imagen profiles` | List editing profiles → `profile_key` for `edit` |
+| `imagen projects` | List projects (`--size`, `--page`) |
+| `imagen edit FOLDER --profile K` | Full workflow: create → upload → edit → download |
+| `imagen enhance PROJECT FILE --tool-id T` | Apply an AI quick tool to an edited image |
+| `imagen i2i FOLDER` | Image-to-image editing workflow |
+| `imagen sky-templates` | Sky replacement template ids |
+| `imagen ai-tools PROJECT` | AI quick tools available for a project |
+| `imagen config` | Show/set persisted defaults |
+
+## Editing workflow
+
+```bash
+# 1. find a profile key
+imagen --json profiles
+
+# 2. edit a folder (downloads results by default)
+imagen --json edit ./raws --profile 328 --type wedding --crop --smooth-skin --out ./edited
+
+# with export to final JPEGs
+imagen --json edit ./raws --profile 328 --export
+```
+
+`edit` accepts a folder or a single file. Edit-option flags map 1:1 to the SDK
+`EditOptions` (`--crop`, `--straighten`, `--hdr-merge`, `--portrait-crop`,
+`--smooth-skin`, `--subject-mask`, `--headshot-crop`, `--perspective-correction`,
+`--sky-replacement`, `--sky-template-id`, `--window-pull`, `--crop-aspect-ratio`).
+Only pass the flags you want on — unset flags are left unset, not forced off.
+
+## Hard rules about input files
+
+- **RAW and JPEG cannot be in the same project.** If a folder mixes them, `edit`
+  fails with `error: input`. Split into a RAW-only run and a JPEG-only run, each
+  with a matching profile (RAW profiles can't process JPEGs and vice versa).
+- The folder scan is **top-level only** — subdirectories (e.g. a previous
+  `edited/` output) are ignored.
+- Supported RAW: `.dng .nef .cr2 .arw .nrw .crw .orf .raw .rw2 .raf .ptx .pef .rwl .srw .cr3 .3fr .fff`
+- Supported JPEG: `.jpg .jpeg`. Other formats (HEIC, etc.) are silently skipped.
+
+## Photography types (`--type`)
+
+`no_type other portraits wedding real_estate landscape_nature events family_newborn boudoir sports school`
+(case-insensitive). Passing the right type improves AI quality.
+
+## Tips
+
+- For long edits, the CLI blocks until editing completes; run it directly so the
+  user sees progress rather than burying it in a subagent.
+- To wire Imagen into a script, `--json` + exit codes are all you need — no SDK
+  import required.


### PR DESCRIPTION
## Summary

Adds an agent-native `imagen` CLI — a thin Click wrapper over the Python SDK — plus an enriched skill teaching agents to drive it. Built on the [CLI-Anything](https://github.com/HKUDS/CLI-Anything) philosophy: **CLI as the universal interface for humans and AI agents**.

The CLI ships as a **standalone binary with no Python required** by end users.

## CLI (`sdks/python/imagen_sdk/cli.py`)

- `--json` output on every command, stable exit codes (`2` auth/config, `1` other), no interactive prompts, self-describing via `--help`.
- API key resolution: `--api-key` → `IMAGEN_API_KEY` → `~/.imagen/config.json`.
- Full API surface: `profiles`, `projects`, `edit` (create→upload→edit→download), `enhance`, `i2i`, `sky-templates`, `ai-tools`, `config`.
- Wired as the `imagen` entry point in `pyproject.toml` (+ `click` dep).

## Python-free distribution

- `packaging/imagen_entry.py` — PyInstaller entry point (absolute import so relative imports resolve when frozen).
- `packaging/install.sh` — `curl … | sh` installer pulling the right binary from the latest release.
- `.github/workflows/release-cli.yml` — on a `cli-v*` tag, builds macOS arm64/x64, Linux x64/arm64, Windows x64 binaries and attaches them to the release.

## Skill (`skills/imagen-cli/SKILL.md`)

Rewritten agent-first: install one-liner, golden rules (`--json`, exit codes, discover-via-`--help`), full command table, RAW/JPEG separation rules, photography types.

## Testing

- `tests/test_cli.py` — 9 tests (JSON/human output, exit codes, arg→SDK mapping, config masking + fallback, mixed RAW/JPEG rejection).
- Full suite: **195 passed**, ruff clean.
- Binary verified in a fully stripped env (`env -i`, no Python) and against the **live API** (real profiles + projects returned).

### Test plan
- [ ] CI green on this PR (`test` job)
- [ ] Tag `cli-v*` once to exercise the cross-platform build matrix (only macOS-arm64 verified locally so far)
- [ ] `curl … | install.sh` end-to-end after first release publishes assets