### PR TITLE
ci(cli): run release build on Blacksmith; drop Intel macOS

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -4,6 +4,10 @@ name: Release CLI
 # platform and attaches them to a GitHub release. Asset names match what
 # sdks/python/packaging/install.sh downloads.
 #
+# Runs on Blacksmith runners (faster/cheaper). Targets: macOS Apple Silicon,
+# Linux x64, Linux arm64, Windows x64. Intel macOS is intentionally not built
+# (Blacksmith has no Intel macOS runner; Intel-Mac users can pip install).
+#
 # Gated on a deliberate `cli-v*` tag so merging to master never publishes.
 # Tests must pass before any binary is built.
 
@@ -19,7 +23,7 @@ defaults:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -35,15 +39,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runner: macos-14      # Apple Silicon
+          - runner: blacksmith-6vcpu-macos-15   # Apple Silicon (no Intel macOS)
             asset: imagen-macos-arm64
-          - runner: macos-13      # Intel
-            asset: imagen-macos-x64
-          - runner: ubuntu-latest
+          - runner: blacksmith-4vcpu-ubuntu-2404
             asset: imagen-linux-x64
-          - runner: ubuntu-24.04-arm
+          - runner: blacksmith-4vcpu-ubuntu-2404-arm
             asset: imagen-linux-arm64
-          - runner: windows-latest
+          - runner: blacksmith-4vcpu-windows-2025
             asset: imagen-windows-x64.exe
     runs-on: ${{ matrix.runner }}
     steps:
@@ -73,7 +75,7 @@ jobs:
     # Only publish a release for an actual cli-v* tag. A manual workflow_dispatch
     # run still builds the binaries (for testing) but does not create a release.
     if: startsWith(github.ref, 'refs/tags/cli-v')
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       contents: write
     steps:

--- a/sdks/python/packaging/install.sh
+++ b/sdks/python/packaging/install.sh
@@ -23,6 +23,13 @@ case "$arch" in
   *) echo "Unsupported architecture: $arch" >&2; exit 1 ;;
 esac
 
+# Intel macOS has no prebuilt binary (no Blacksmith Intel-macOS runner).
+if [ "$plat" = "macos" ] && [ "$a" = "x64" ]; then
+  echo "Intel macOS has no prebuilt binary. Install from source instead:" >&2
+  echo "  pip install imagen-ai-sdk    # provides the 'imagen' command" >&2
+  exit 1
+fi
+
 asset="imagen-${plat}-${a}"
 if [ "${IMAGEN_VERSION:-latest}" = "latest" ]; then
   url="https://github.com/${REPO}/releases/latest/download/${asset}"


### PR DESCRIPTION
Moves the `imagen` CLI release build to Blacksmith runners (faster/cheaper, matches our other repos) and drops the Intel macOS target.

## Changes
- All jobs (`test`, `build` matrix, `release`) run on Blacksmith runners.
- Targets: macOS Apple Silicon (`blacksmith-6vcpu-macos-15`), Linux x64/arm64 (`blacksmith-4vcpu-ubuntu-2404[-arm]`), Windows x64 (`blacksmith-4vcpu-windows-2025`).
- **Intel macOS dropped** — Blacksmith has no Intel macOS runner, it was the queue bottleneck, and demand is fading. `install.sh` now tells Intel-Mac users to `pip install` instead of 404ing.

## Why
The prior GitHub-runner release was stuck **30+ min** on the `macos-13` (Intel) queue before being cancelled. Blacksmith eliminates that.

## Test build (workflow_dispatch on this branch, no publish)
Run 29329317443 — all green in <2 min; `release` correctly skipped (dispatch, not a tag); all 4 platform artifacts produced.

## Published release (after merge, `cli-v1.1.1` tag) ✅
Run 29329527551 — **all jobs green, release published**:

| Job | Runner | Result | Time |
|-----|--------|--------|------|
| test | Blacksmith Linux | ✅ | 11s |
| macOS arm64 | Blacksmith M4 | ✅ | 19s |
| Linux x64 | Blacksmith | ✅ | 23s |
| Windows x64 | Blacksmith 2025 (beta) | ✅ | 30s |
| Linux arm64 | Blacksmith | ✅ | 50s |
| release (publish) | Blacksmith Linux | ✅ | 17s |

Full pipeline including publish finished in ~1.5 min (vs 30+ min stuck on GitHub's Intel-macOS queue).

### Release `cli-v1.1.1` assets published
- imagen-macos-arm64 (12.8 MB)
- imagen-linux-x64 (25.5 MB)
- imagen-linux-arm64 (24.5 MB)
- imagen-windows-x64.exe (13.7 MB)

### End-to-end install verified
`curl -fsSL .../install.sh | sh` → installed `imagen-macos-arm64` → `imagen --version` = 1.1.1 → `imagen --json profiles` returned live API data. The `releases/latest/download/...` URL now resolves (HTTP 200).

## Note
Windows-2025 on Blacksmith is still public beta. It passed cleanly; fallback if it ever flakes is `windows-latest` on GitHub for that one job.