### PR TITLE
feat(cli): add `imagen skill` command with Claude + Codex agent skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ curl -fsSL https://raw.githubusercontent.com/imagenai/imagen-ai-sdk/master/sdks/
 imagen edit ./raws --profile 328 --type wedding --crop
 ```
 
+Driving it from an AI agent (Claude Code or OpenAI Codex)? Run
+`imagen skill --claude --install` or `imagen skill --codex --install` to drop a
+skill into the agent's discovery dir so it learns the full command surface.
+
 ## Repository layout
 
 ```

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -75,6 +75,7 @@ self-documenting.
 | `imagen sky-templates` | List sky-replacement template ids |
 | `imagen ai-tools PROJECT` | List AI quick tools available for a project |
 | `imagen config` | Show or set persisted defaults |
+| `imagen skill` | Print or install the agent skill that teaches an AI agent to drive this CLI |
 
 ### Global options
 
@@ -159,6 +160,26 @@ fi
 
 ## For AI agents
 
-An installable skill (`skills/imagen-cli/SKILL.md`) teaches agents to drive this
+The CLI ships an **agent skill** — a `SKILL.md` with `name`/`description`
+frontmatter (`skills/imagen-cli/SKILL.md`) — that teaches an agent to drive this
 CLI: always use `--json`, check exit codes, and discover capabilities via
-`--help` rather than hardcoding commands.
+`--help` rather than hardcoding commands. Claude Code and OpenAI Codex use the
+**same skill format**, so one skill serves both agents.
+
+`imagen skill` makes it self-bootstrapping — no repo checkout needed, since the
+skill text is embedded in the binary:
+
+```bash
+imagen skill                        # print the skill to stdout
+imagen skill --codex                # identical text (flags only pick install dir)
+imagen --json skill                 # {"format": "...", "content": "..."}  (--json is global, goes first)
+
+# Install it where the agent auto-discovers skills by their frontmatter:
+imagen skill --claude --install     # -> ~/.claude/skills/imagen-cli/SKILL.md
+imagen skill --codex  --install     # -> ~/.codex/skills/imagen-cli/SKILL.md
+```
+
+`--claude` / `--codex` only choose the **install location** — the skill content
+is identical. To feed it into an agent that reads instructions from stdin/context
+instead of a skills dir, just pipe the printed output. Install honors `--json` and
+the standard exit codes, so failures are machine-readable too.

--- a/sdks/python/imagen_sdk/__init__.py
+++ b/sdks/python/imagen_sdk/__init__.py
@@ -128,7 +128,7 @@ from .models import (
 )
 
 # Version info
-__version__ = "1.1.1"
+__version__ = "1.2.0"
 __author__ = "Shahar Polak"
 __email__ = "shahar@imagen-ai.com"
 __description__ = "A robust, Pydantic-powered SDK for the Imagen AI photo editing workflow"

--- a/sdks/python/imagen_sdk/cli.py
+++ b/sdks/python/imagen_sdk/cli.py
@@ -41,6 +41,7 @@ from .imagen_sdk import (
     quick_edit,
 )
 from .models import EditOptions, I2IEditOptions
+from .skill_text import INSTALL_PATHS, SKILLS
 
 CONFIG_PATH = Path.home() / ".imagen" / "config.json"
 
@@ -448,6 +449,31 @@ def config(ctx: dict[str, Any], api_key: str | None, profile: int | None, base_u
             click.echo(f"{k} = {val}")
 
     _emit(ctx, view, human)
+
+
+@cli.command()
+@click.option("--claude", "fmt", flag_value="claude", default=True, help="Target Claude Code's skills dir (default).")
+@click.option("--codex", "fmt", flag_value="codex", help="Target Codex's skills dir.")
+@click.option("--install", is_flag=True, help="Write the skill into the agent's skills dir instead of printing it.")
+@click.pass_obj
+def skill(ctx: dict[str, Any], fmt: str, install: bool) -> None:
+    """Print (or --install) the agent skill for driving this CLI.
+
+    The skill text is the same for both agents; `--claude` / `--codex` only pick
+    the install location. Pipe it into an agent's context, or `--install` it so
+    the agent auto-discovers it (`~/.claude/skills/…` or `~/.codex/skills/…`).
+    """
+    text = SKILLS[fmt]
+    if install:
+        dest = Path.home() / INSTALL_PATHS[fmt]
+        try:
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            dest.write_text(text, encoding="utf-8")
+        except OSError as exc:
+            _fail(ctx, "error", f"Could not write skill to {dest}: {exc}", 1)
+        _emit(ctx, {"format": fmt, "path": str(dest)}, lambda d: click.echo(f"Installed {fmt} skill to {d['path']}"))
+        return
+    _emit(ctx, {"format": fmt, "content": text}, lambda _d: click.echo(text, nl=False))
 
 
 def main() -> None:

--- a/sdks/python/imagen_sdk/skill_text.py
+++ b/sdks/python/imagen_sdk/skill_text.py
@@ -1,4 +1,19 @@
----
+"""Embedded agent skill for the `imagen` CLI.
+
+The standalone binary can't read the repo's `skills/` folder at runtime, so the
+skill text lives here as the single source of truth. `imagen skill` prints or
+installs it, and the committed copies are generated from this constant — a test
+fails if they drift.
+
+Claude Code and Codex use the *same* skill format: a `SKILL.md` with `name` /
+`description` frontmatter, discovered from a per-agent skills dir. They differ
+only in *where* the skill is installed (see INSTALL_PATHS), so there is one skill
+body, not two.
+"""
+
+from __future__ import annotations
+
+SKILL_MD = """---
 name: imagen-cli
 description: "Use whenever an agent or user needs to edit, cull, or process photos with Imagen AI from the command line. Triggers on: 'edit my photos', 'run imagen', 'use the imagen CLI', 'AI edit these RAW/JPEG files', 'batch process wedding/portrait/real-estate photos', 'list my imagen profiles/projects', 'enhance an edited image', 'image-to-image edit'. The `imagen` CLI is a single self-contained binary (no Python required) that wraps the full Imagen AI API. Prefer it over hand-writing SDK code."
 ---
@@ -92,3 +107,23 @@ Only pass the flags you want on — unset flags are left unset, not forced off.
   user sees progress rather than burying it in a subagent.
 - To wire Imagen into a script, `--json` + exit codes are all you need — no SDK
   import required.
+"""
+
+# Same skill content for both agents; the only difference is the install home.
+SKILLS = {"claude": SKILL_MD, "codex": SKILL_MD}
+
+# Where `imagen skill --install` writes each agent's copy (relative to $HOME).
+# Each is that agent's own skills dir, where it auto-discovers SKILL.md by its
+# frontmatter, and a dedicated namespaced subdir so install never clobbers
+# unrelated files. (Codex also reads a cross-agent `~/.agents/skills/`, but we
+# install into its own `~/.codex/skills/` to keep the two agents symmetric.)
+INSTALL_PATHS = {
+    "claude": ".claude/skills/imagen-cli/SKILL.md",
+    "codex": ".codex/skills/imagen-cli/SKILL.md",
+}
+
+# Committed copy (repo-relative), generated from SKILL_MD. One file serves both
+# agents since the format is identical; each agent gets its own installed copy via
+# `imagen skill --claude|--codex --install` (see INSTALL_PATHS). We don't commit a
+# `.agents/skills/` copy because that dir is gitignored in this repo.
+REPO_SKILL_FILES = ("skills/imagen-cli/SKILL.md",)

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -110,3 +110,7 @@ fix = true
 [tool.ruff.lint]
 select = ["E", "F", "W", "I"]
 ignore = []
+
+[tool.ruff.lint.per-file-ignores]
+# Embedded agent-guide prose — line length is not meaningful here.
+"imagen_sdk/skill_text.py" = ["E501"]

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "imagen-ai-sdk"
-version = "1.1.1"
+version = "1.2.0"
 description = "A robust, Pydantic-powered SDK for the Imagen AI photo editing workflow"
 authors = [{name = "Shahar Polak", email = "shahar@imagen-ai.com"}]
 license = {text = "MIT"}

--- a/sdks/python/tests/test_cli.py
+++ b/sdks/python/tests/test_cli.py
@@ -293,3 +293,67 @@ def test_config_value_used_as_fallback(runner):
         result = runner.invoke(cli, ["--json", "profiles"])
     assert result.exit_code == 0
     assert seen["api_key"] == "FROMFILE"
+
+
+# --------------------------------------------------------------------------- #
+# skill command                                                               #
+# --------------------------------------------------------------------------- #
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+@pytest.mark.parametrize("fmt", ["claude", "codex"])
+def test_skill_prints_full_skill_with_frontmatter(runner, fmt):
+    # Both agents use the same SKILL.md format; Codex needs the frontmatter
+    # (name/description) for discovery too, so it must NOT be stripped.
+    result = runner.invoke(cli, ["skill", f"--{fmt}"])
+    assert result.exit_code == 0
+    assert result.output.startswith("---\nname: imagen-cli")
+    assert result.output == cli_mod.SKILLS[fmt]
+
+
+def test_skill_defaults_to_claude(runner):
+    assert runner.invoke(cli, ["skill"]).output == runner.invoke(cli, ["skill", "--claude"]).output
+
+
+def test_skill_json_wraps_content(runner):
+    result = runner.invoke(cli, ["--json", "skill", "--codex"])
+    assert result.exit_code == 0
+    doc = json.loads(result.output)
+    assert doc["format"] == "codex"
+    assert doc["content"] == cli_mod.SKILLS["codex"]
+
+
+@pytest.mark.parametrize(
+    "fmt,rel",
+    [
+        # Literal expected paths, so a wrong INSTALL_PATHS constant is caught here
+        # rather than silently agreeing with itself.
+        ("claude", ".claude/skills/imagen-cli/SKILL.md"),
+        ("codex", ".codex/skills/imagen-cli/SKILL.md"),
+    ],
+)
+def test_skill_install_writes_to_agent_dir(runner, tmp_path, monkeypatch, fmt, rel):
+    monkeypatch.setattr(cli_mod.Path, "home", staticmethod(lambda: tmp_path))
+    result = runner.invoke(cli, ["--json", "skill", f"--{fmt}", "--install"])
+    assert result.exit_code == 0
+    dest = tmp_path / rel
+    assert dest.read_text(encoding="utf-8") == cli_mod.SKILLS[fmt]
+    assert json.loads(result.output)["path"] == str(dest)
+
+
+def test_skill_install_error_honors_json(runner, tmp_path, monkeypatch):
+    monkeypatch.setattr(cli_mod.Path, "home", staticmethod(lambda: tmp_path))
+    monkeypatch.setattr(cli_mod.Path, "write_text", lambda *a, **k: (_ for _ in ()).throw(OSError("disk full")))
+    result = runner.invoke(cli, ["--json", "skill", "--install"])
+    assert result.exit_code == 1
+    assert json.loads(result.output)["error"] == "error"
+
+
+def test_repo_skills_match_embedded_source():
+    # The embedded string is the source of truth; the committed skill copies
+    # (Claude + Codex) are generated from it and must not drift.
+    from imagen_sdk.skill_text import REPO_SKILL_FILES
+
+    for rel in REPO_SKILL_FILES:
+        assert (_REPO_ROOT / rel).read_text() == cli_mod.SKILLS["claude"], rel


### PR DESCRIPTION
## Summary

Adds an `imagen skill` command so both **Claude Code** and **OpenAI Codex** agents can discover and drive the `imagen` CLI.

- New command: `imagen skill [--claude|--codex] [--install]`
  - Prints the agent skill to stdout, or `--install`s it to the agent's own skills dir (`~/.claude/skills/imagen-cli/SKILL.md` or `~/.codex/skills/imagen-cli/SKILL.md`).
  - Both agents use the **same** `SKILL.md`+frontmatter format; the flags pick only the install location. Content is identical.
  - Honors global `--json` and the CLI's stable exit codes; install failures map to a JSON error.
- Skill text is embedded in the binary (single source of truth: `imagen_sdk/skill_text.py`), so the command works with no repo checkout.
- Committed `skills/imagen-cli/SKILL.md` is generated from the embedded string and guarded against drift by a test.
- Version bumped `1.1.1` → `1.2.0`.

## Test plan

- [x] 28 CLI tests pass (print both formats, install to literal per-agent paths, JSON error path, drift guard); 214 full suite green.
- [x] `ruff check` + `ruff format` clean.
- [x] Live: real edit workflow end-to-end via the API; a fresh Codex session discovered the installed skill and read its rules.
- [x] Independent Codex review of code + tests + docs — approved, findings addressed.

## Release (post-merge, tag-gated)

- `cli-v1.2.0` → rebuilds standalone binaries (end users / agents).
- `python-v1.2.0` → publishes to PyPI (keeps package + binary in sync). Requires PyPI Trusted-Publishing setup for this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)