### PR TITLE
docs: add AGENTS.md + RELEASING.md, fix agent-doc accuracy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,81 @@
+# AGENTS.md
+
+Guidance for AI coding agents (Codex, Claude, etc.) working **on** this repo.
+Using the tools instead of contributing to them? See
+[`skills/imagen-cli/SKILL.md`](skills/imagen-cli/SKILL.md) (drive the CLI) and
+[`docs/CLI.md`](docs/CLI.md).
+
+## What this is
+
+A multi-language SDK monorepo for the Imagen AI photo-editing API. The Python SDK
+(`sdks/python/`) also produces the standalone `imagen` CLI. Node (`sdks/node/`) and
+Go (`sdks/go/`) are independent ports. **Most active development is in
+`sdks/python/` — run the commands below from there.**
+
+## Setup, test, lint
+
+**Python** (`sdks/python/`) — the primary package + the `imagen` CLI:
+
+```bash
+cd sdks/python
+pip install -e ".[dev]"           # installs the SDK + the `imagen` command from live source
+python -m pytest tests/           # run tests (asyncio; ~200 tests)
+python -m pytest tests/test_cli.py  # CLI-only tests
+python -m imagen_sdk.cli --help   # run the CLI from source (no build needed)
+python -m ruff check imagen_sdk/  # lint (line-length 140)
+python -m ruff format imagen_sdk/
+python -m mypy imagen_sdk/        # type check
+sh packaging/build.sh             # build the standalone binary -> dist/imagen (rarely needed locally)
+```
+
+**Node** (`sdks/node/`): `npm ci` · `npm run lint` · `npm run typecheck` · `npm run build` · `npm test`
+**Go** (`sdks/go/`): `go test -v -race ./...`
+
+`pre-commit run --all-files` runs ruff check + format (config at repo root). The
+hooks reformat on commit — if a commit aborts saying files were modified, re-stage
+and commit again. CI (`.github/workflows/ci.yml`) is path-filtered, so it only runs
+the language whose files changed.
+
+## The `imagen` CLI
+
+`imagen_sdk/cli.py` is a thin Click wrapper over the SDK. Keep its **design
+contract** true when adding commands (details in
+[CLAUDE.md](CLAUDE.md#command-line-interface-imagen) / [docs/CLI.md](docs/CLI.md)):
+
+- Every command supports `--json`; never prompts. Success JSON goes to stdout,
+  error JSON (`{"error","message"}`) goes to stderr.
+- Stable exit codes: `0` success, `2` auth/config, `1` any other error.
+- New editing flags must map to the exact SDK model field name (Pydantic drops
+  unknown fields silently).
+- The CLI ships as a **PyInstaller binary** built from SDK source — editing
+  `imagen_sdk/` does not change an already-built binary; contributors run from
+  source via `pip install -e`.
+- The agent skill text is embedded in `imagen_sdk/skill_text.py` (single source of
+  truth); the committed `skills/imagen-cli/SKILL.md` is generated from it and a
+  test (`test_repo_skills_match_embedded_source`) fails if they drift. Edit the
+  module, then regenerate the committed copy — don't hand-edit `SKILL.md`.
+
+## Domain gotcha
+
+RAW and JPEG files **cannot be mixed in one project/edit** — RAW profiles can't
+process JPEGs and vice versa. Split into RAW-only and JPEG-only runs. See
+[docs/WORKFLOWS.md](docs/WORKFLOWS.md) for the full behavioral contract every SDK
+implements.
+
+## Versioning & releasing
+
+- **Version bump lives in two places that must match**:
+  `sdks/python/pyproject.toml` (`version`) and
+  `sdks/python/imagen_sdk/__init__.py` (`__version__`, which `imagen --version`
+  reads). A new backward-compatible command/feature is a **minor** bump.
+- **Nothing publishes on merge.** Releases are gated on prefixed tags:
+  `python-v*` → PyPI, `cli-v*` → binaries, `node-v*` → npm. Go has no publish
+  workflow — it's `go get` from an `sdks/go/vX.Y.Z` tag. Full process (including
+  PyPI Trusted-Publishing setup) in [docs/RELEASING.md](docs/RELEASING.md).
+
+## Git rules (hard)
+
+- **Never push to `master`.** All changes go through a PR (`gh pr create --base master`).
+- Branch off master with its own upstream; don't create branches that track
+  `origin/master`.
+- Don't commit unless asked. No secrets in tracked files.

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ See each SDK's own README for full usage and examples.
 ## Command-line tool
 
 Prefer the terminal (or driving Imagen from an AI agent)? The **`imagen` CLI** is
-a single self-contained binary — no Python required — that wraps the full API
-with `--json` output and stable exit codes. See [`docs/CLI.md`](docs/CLI.md).
+a single self-contained binary — no Python required — that wraps the core editing
+workflows with `--json` output and stable exit codes. See [`docs/CLI.md`](docs/CLI.md).
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/imagenai/imagen-ai-sdk/master/sdks/python/packaging/install.sh | sh
@@ -44,6 +44,24 @@ with releases cut as `sdks/go/vX.Y.Z` tags.
 The workflows every SDK implements (create → upload → edit → poll → download,
 plus export, AI enhancement, and image-to-image) are defined language-neutrally in
 [`docs/WORKFLOWS.md`](docs/WORKFLOWS.md).
+
+## For AI agents
+
+- **Using Imagen from an agent?** The `imagen` CLI is agent-native (`--json`,
+  stable exit codes, self-describing via `--help`). Install the skill so your
+  agent discovers it: `imagen skill --claude --install` or
+  `imagen skill --codex --install`. Details in [`docs/CLI.md`](docs/CLI.md); the
+  skill itself is [`skills/imagen-cli/SKILL.md`](skills/imagen-cli/SKILL.md).
+- **Contributing to this repo with a coding agent?** Read
+  [`AGENTS.md`](AGENTS.md) — build/test/lint commands, the CLI design contract,
+  versioning, and the never-push-to-master rule.
+
+## Releasing
+
+Each SDK releases independently on a prefixed git tag (`python-v*`, `cli-v*`,
+`node-v*`); merging to `master` never publishes. See
+[`docs/RELEASING.md`](docs/RELEASING.md) for the full process, including PyPI
+Trusted-Publishing setup.
 
 ## License
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1,9 +1,10 @@
 # `imagen` CLI
 
 A standalone command-line tool for the Imagen AI photo-editing API. It wraps the
-full API surface and is built to be driven by **both humans and AI agents**:
+core editing workflows and is built to be driven by **both humans and AI agents**:
 every command supports `--json`, uses stable exit codes, and never prompts
-interactively.
+interactively. (A few low-level SDK operations aren't exposed as commands — see
+the SDK for those.)
 
 **No Python required** — the CLI ships as a single self-contained binary.
 
@@ -126,7 +127,7 @@ Passing the right type improves AI quality.
   matching profile (RAW profiles can't process JPEGs and vice versa).
 - Only the **top level** of the folder is scanned; subfolders (e.g. a previous
   `edited/` output) are ignored.
-- Supported RAW: `.dng .nef .cr2 .arw .nrw .crw .orf .raw .rw2 .raf .ptx .pef .rwl .srw .cr3 .3fr .fff`
+- Supported RAW: `.dng .nef .cr2 .arw .nrw .crw .orf .raw .rw2 .raf .ptx .pef .rwl .srw .cr3 .3fr .fff .srf .sr2`
 - Supported JPEG: `.jpg .jpeg`. Other formats (HEIC, etc.) are skipped.
 
 ---
@@ -149,10 +150,11 @@ imagen --json profiles | jq '.[0].profile_key'
 ```
 
 ```bash
-if imagen --json edit ./raws --profile 328 > result.json; then
+# Success JSON goes to stdout; error JSON goes to stderr — capture them separately.
+if imagen --json edit ./raws --profile 328 >result.json 2>error.json; then
   jq -r '.downloaded_files[]' result.json
 else
-  jq -r '.message' result.json >&2   # error detail on stderr
+  jq -r '.message' error.json >&2   # error detail is on stderr
 fi
 ```
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,84 @@
+# Releasing
+
+Each SDK releases independently, and **nothing publishes on merge**. Every release
+is gated on a deliberate, prefixed git tag pushed to `master`, and every publish
+job `needs: test`, so a failing suite blocks the upload (fails closed).
+
+| What | Tag prefix | Workflow | Target |
+|------|-----------|----------|--------|
+| Python SDK | `python-v*` | `.github/workflows/release-python.yml` | PyPI (`imagen-ai-sdk`) |
+| Standalone CLI binary | `cli-v*` | `.github/workflows/release-cli.yml` | GitHub Releases (macOS/Linux/Windows binaries) |
+| Node SDK | `node-v*` | `.github/workflows/release-node.yml` | npm |
+
+The Python package and the CLI binary are **built from the same `sdks/python`
+source**, so they share one version. Keep them in sync: when you cut one, cut the
+other at the same version.
+
+The **Go SDK** has no publish workflow — it's consumed directly via `go get` from a
+`sdks/go/vX.Y.Z` tag, so "releasing" it is just pushing that tag.
+
+## Releasing the Python SDK (PyPI)
+
+1. **Bump the version in both places** (they must match — `imagen --version` reads
+   `__version__`):
+   - `sdks/python/pyproject.toml` → `version = "X.Y.Z"`
+   - `sdks/python/imagen_sdk/__init__.py` → `__version__ = "X.Y.Z"`
+
+   Use semver: a new command / backward-compatible feature is a **minor** bump.
+
+2. Merge that to `master` via PR (branch protection — never push to `master`).
+
+3. Tag the merged commit and push the tag:
+   ```bash
+   git checkout master && git pull --ff-only origin master
+   git tag -a python-vX.Y.Z -m "imagen-ai-sdk X.Y.Z — <summary>"
+   git push origin python-vX.Y.Z
+   ```
+
+4. Watch the run: `gh run list --limit 5`. The `publish` job uploads to PyPI once
+   `test` passes.
+
+### PyPI auth: Trusted Publishing (one-time setup)
+
+The `publish` job authenticates with **PyPI Trusted Publishing (OIDC)** — no stored
+token, nothing on any developer's machine. What's authorized is the *workflow
+identity*, not a computer.
+
+If the publish step fails with `invalid-publisher` ("no corresponding publisher"),
+the trusted publisher hasn't been registered yet. Register it once, on
+[pypi.org](https://pypi.org) → project `imagen-ai-sdk` →
+**Settings → Publishing → Add a trusted publisher (GitHub)**:
+
+| Field | Value |
+|-------|-------|
+| Owner | `imagenai` |
+| Repository name | `imagen-ai-sdk` |
+| Workflow name | `release-python.yml` |
+| Environment name | `pypi` |
+
+(If the project didn't exist on PyPI yet, add a **pending** publisher from the
+account level instead.) Once added, re-run the failed job — no re-tag needed:
+
+```bash
+gh run rerun <run-id> --failed
+```
+
+Verify: `pip index versions imagen-ai-sdk`, or check
+`https://pypi.org/project/imagen-ai-sdk/`.
+
+## Releasing the CLI binary
+
+Same version, `cli-v*` tag:
+
+```bash
+git tag -a cli-vX.Y.Z -m "imagen CLI X.Y.Z — <summary>"
+git push origin cli-vX.Y.Z
+```
+
+`release-cli.yml` rebuilds binaries for macOS arm64, Linux x64/arm64, and Windows
+x64 (via `sdks/python/packaging/build.sh`, the same script contributors run
+locally) and attaches them to a GitHub Release. `packaging/install.sh` (the
+`curl | sh` installer) downloads them.
+
+The CLI binary is not published to any package registry — GitHub Releases is its
+only distribution channel. See [CLI.md](CLI.md) for install/usage.

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -5,8 +5,8 @@
 Transform your post-production workflow with AI-powered batch editing. Upload hundreds of photos, apply professional edits automatically, and get download links in minutes.
 
 > **Prefer the command line?** This package also ships the `imagen` CLI — a
-> standalone binary (no Python required) that wraps the full API with `--json`
-> output for scripts and AI agents. See [`../../docs/CLI.md`](../../docs/CLI.md).
+> standalone binary (no Python required) that wraps the core editing workflows
+> with `--json` output for scripts and AI agents. See [`../../docs/CLI.md`](../../docs/CLI.md).
 
 ---
 

--- a/sdks/python/imagen_sdk/skill_text.py
+++ b/sdks/python/imagen_sdk/skill_text.py
@@ -15,15 +15,17 @@ from __future__ import annotations
 
 SKILL_MD = """---
 name: imagen-cli
-description: "Use whenever an agent or user needs to edit, cull, or process photos with Imagen AI from the command line. Triggers on: 'edit my photos', 'run imagen', 'use the imagen CLI', 'AI edit these RAW/JPEG files', 'batch process wedding/portrait/real-estate photos', 'list my imagen profiles/projects', 'enhance an edited image', 'image-to-image edit'. The `imagen` CLI is a single self-contained binary (no Python required) that wraps the full Imagen AI API. Prefer it over hand-writing SDK code."
+description: "Use whenever an agent or user needs to edit, cull, or process photos with Imagen AI from the command line. Triggers on: 'edit my photos', 'run imagen', 'use the imagen CLI', 'AI edit these RAW/JPEG files', 'batch process wedding/portrait/real-estate photos', 'list my imagen profiles/projects', 'enhance an edited image', 'image-to-image edit'. The `imagen` CLI is a single self-contained binary (no Python required) that wraps the core Imagen AI editing workflows. Prefer it over hand-writing SDK code."
 ---
 
 # Imagen CLI (agent-native)
 
-`imagen` is a standalone binary wrapping the whole Imagen AI API. It is built to
-be driven by agents: non-interactive, `--json` output, stable exit codes, and
-fully self-describing via `--help`. **You do not need to memorize the command
-surface — discover it at runtime.**
+`imagen` is a standalone binary wrapping the core Imagen AI editing workflows. It
+is built to be driven by agents: non-interactive, `--json` output, stable exit
+codes, and fully self-describing via `--help`. **You do not need to memorize the
+command surface — discover it at runtime.** (A few low-level SDK operations aren't
+exposed as commands — if `imagen <cmd> --help` doesn't list what you need, use the
+SDK directly.)
 
 ## First: make sure it's installed
 
@@ -93,7 +95,7 @@ Only pass the flags you want on — unset flags are left unset, not forced off.
   with a matching profile (RAW profiles can't process JPEGs and vice versa).
 - The folder scan is **top-level only** — subdirectories (e.g. a previous
   `edited/` output) are ignored.
-- Supported RAW: `.dng .nef .cr2 .arw .nrw .crw .orf .raw .rw2 .raf .ptx .pef .rwl .srw .cr3 .3fr .fff`
+- Supported RAW: `.dng .nef .cr2 .arw .nrw .crw .orf .raw .rw2 .raf .ptx .pef .rwl .srw .cr3 .3fr .fff .srf .sr2`
 - Supported JPEG: `.jpg .jpeg`. Other formats (HEIC, etc.) are silently skipped.
 
 ## Photography types (`--type`)

--- a/skills/imagen-cli/SKILL.md
+++ b/skills/imagen-cli/SKILL.md
@@ -1,14 +1,16 @@
 ---
 name: imagen-cli
-description: "Use whenever an agent or user needs to edit, cull, or process photos with Imagen AI from the command line. Triggers on: 'edit my photos', 'run imagen', 'use the imagen CLI', 'AI edit these RAW/JPEG files', 'batch process wedding/portrait/real-estate photos', 'list my imagen profiles/projects', 'enhance an edited image', 'image-to-image edit'. The `imagen` CLI is a single self-contained binary (no Python required) that wraps the full Imagen AI API. Prefer it over hand-writing SDK code."
+description: "Use whenever an agent or user needs to edit, cull, or process photos with Imagen AI from the command line. Triggers on: 'edit my photos', 'run imagen', 'use the imagen CLI', 'AI edit these RAW/JPEG files', 'batch process wedding/portrait/real-estate photos', 'list my imagen profiles/projects', 'enhance an edited image', 'image-to-image edit'. The `imagen` CLI is a single self-contained binary (no Python required) that wraps the core Imagen AI editing workflows. Prefer it over hand-writing SDK code."
 ---
 
 # Imagen CLI (agent-native)
 
-`imagen` is a standalone binary wrapping the whole Imagen AI API. It is built to
-be driven by agents: non-interactive, `--json` output, stable exit codes, and
-fully self-describing via `--help`. **You do not need to memorize the command
-surface — discover it at runtime.**
+`imagen` is a standalone binary wrapping the core Imagen AI editing workflows. It
+is built to be driven by agents: non-interactive, `--json` output, stable exit
+codes, and fully self-describing via `--help`. **You do not need to memorize the
+command surface — discover it at runtime.** (A few low-level SDK operations aren't
+exposed as commands — if `imagen <cmd> --help` doesn't list what you need, use the
+SDK directly.)
 
 ## First: make sure it's installed
 
@@ -78,7 +80,7 @@ Only pass the flags you want on — unset flags are left unset, not forced off.
   with a matching profile (RAW profiles can't process JPEGs and vice versa).
 - The folder scan is **top-level only** — subdirectories (e.g. a previous
   `edited/` output) are ignored.
-- Supported RAW: `.dng .nef .cr2 .arw .nrw .crw .orf .raw .rw2 .raf .ptx .pef .rwl .srw .cr3 .3fr .fff`
+- Supported RAW: `.dng .nef .cr2 .arw .nrw .crw .orf .raw .rw2 .raf .ptx .pef .rwl .srw .cr3 .3fr .fff .srf .sr2`
 - Supported JPEG: `.jpg .jpeg`. Other formats (HEIC, etc.) are silently skipped.
 
 ## Photography types (`--type`)


### PR DESCRIPTION
## Summary

Follow-up to the `imagen skill` feature (#12): make the repo's docs solid for **both** kinds of AI agents, and fix accuracy drift an independent Codex audit flagged.

**New docs**
- **`AGENTS.md`** (repo root) — contributor router for coding agents (Codex et al.): per-language build/test/lint (Python/Node/Go), the CLI design contract, the embedded-skill single-source-of-truth + drift guard, the two-place version bump, tag-gated releases, and the never-push-to-master rule. Links to source-of-truth docs instead of duplicating.
- **`docs/RELEASING.md`** — the per-SDK tag-gated release process (`python-v*`/`cli-v*`/`node-v*`, Go via `sdks/go/v*`), including the one-time PyPI Trusted-Publishing setup.
- **README** — a "For AI agents" section splitting tool-users (SKILL.md/CLI.md) from contributors (AGENTS.md); plus a Releasing pointer.

**Accuracy fixes (were misleading agents)**
- Softened the "wraps the *full* API" overclaim → "core editing workflows" in README, docs/CLI.md, the embedded skill, and the Python README (the CLI doesn't expose every SDK operation).
- Added `.srf`/`.sr2` to the CLI + skill RAW-extension lists to match `RAW_EXTENSIONS`.
- Fixed the docs/CLI.md JSON example to capture stderr separately (error JSON is on stderr, not stdout).

## Test plan

- [x] SKILL.md regenerated from `skill_text.py`; drift guard + 28 CLI tests pass.
- [x] `ruff check` + `ruff format` clean (pre-commit).
- [x] Two independent Codex passes: an audit that drove the accuracy fixes, and a review of `AGENTS.md` — all findings addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)