### PR TITLE
docs: add CHANGELOG.md for the Python SDK / CLI

### DIFF
--- a/sdks/python/CHANGELOG.md
+++ b/sdks/python/CHANGELOG.md
@@ -1,0 +1,37 @@
+# Changelog
+
+All notable changes to the `imagen-ai-sdk` Python package (and the `imagen` CLI
+built from it) are documented here. This project follows
+[Semantic Versioning](https://semver.org/) and the
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format.
+
+## [1.2.0] - 2026-07-20
+
+### Added
+
+- **`imagen skill` CLI command** — prints or installs an agent skill that teaches
+  an AI coding agent to drive the CLI. `--claude` / `--codex` choose the install
+  location (`~/.claude/skills/imagen-cli/SKILL.md` or
+  `~/.codex/skills/imagen-cli/SKILL.md`); both agents use the same `SKILL.md`
+  format, so the content is identical. Honors the global `--json` flag and the
+  CLI's stable exit codes.
+- Embedded skill text as a single source of truth (`imagen_sdk/skill_text.py`);
+  the committed `skills/imagen-cli/SKILL.md` is generated from it and guarded
+  against drift by a test.
+
+### Documentation
+
+- Added a root `AGENTS.md` (contributor guide for coding agents) and
+  `docs/RELEASING.md` (per-SDK tag-gated release process, incl. PyPI
+  Trusted-Publishing setup).
+- Rewrote the root `README.md` into a developer-focused landing page and
+  documented `imagen skill` in `docs/CLI.md`.
+- Corrected doc drift: the CLI wraps the *core editing workflows* (not the full
+  API); added the `.srf`/`.sr2` RAW extensions to the supported-format lists.
+
+## Earlier releases
+
+For 1.1.0 and earlier, see the version-tagged notes in
+[`README.md`](README.md) (e.g. the "New in v1.1.0" section covering AI
+enhancement/copilot, image-to-image, project management, sky-replacement
+templates, and per-image export links).


### PR DESCRIPTION
## Summary

Adds a [Keep a Changelog](https://keepachangelog.com/) changelog for the
`imagen-ai-sdk` Python package (and the `imagen` CLI built from it) — the repo had
none. It's placed at `sdks/python/CHANGELOG.md` because that package carries the
version and the release; the SDKs version independently, so per-package changelogs
fit better than a repo-root one.

The `[1.2.0] - 2026-07-20` entry documents everything shipped in this cycle:

- **Added** — the `imagen skill` command (print/install, `--claude`/`--codex`,
  `--json`, stable exit codes) and the embedded single-source skill text with a
  drift-guard test.
- **Documentation** — `AGENTS.md`, `docs/RELEASING.md`, the root README rewrite,
  `docs/CLI.md` skill docs, and the accuracy fixes (core-workflows wording,
  `.srf`/`.sr2` RAW extensions).

Earlier history points to the README's existing "New in v1.1.0" notes rather than
reconstructing older releases with guessed dates.

Follow-up to #12, #13, #14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)