### PR TITLE
chore: add context7.json for Context7 docs indexing

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,0 +1,4 @@
+{
+  "url": "https://context7.com/imagenai/imagen-ai-sdk",
+  "public_key": "pk_JETbfJVgJ2MCD7JP7iQ3D"
+}


### PR DESCRIPTION
Adds `context7.json` pointing Context7 at this repo for docs indexing.

- url: https://context7.com/imagenai/imagen-ai-sdk
- public_key for the project